### PR TITLE
Added Core Data support to NSRails

### DIFF
--- a/nsrails/Source/NSRConfig.m
+++ b/nsrails/Source/NSRConfig.m
@@ -54,6 +54,13 @@
 }
 @end
 
+@interface NSRConfig()
+
+- (void) logRequestWithBody:(NSString *)body httpVerb:(NSString *)httpVerb url:(NSString *)url;
+- (NSURLRequest *) HTTPRequestForRequestType:(NSString *)type requestBody:(NSString *)requestStr url:(NSString *)url;
+- (void) logResponse:(NSString *)response statusCode:(int)code;
+
+@end
 
 //Environments
 NSString * const NSRConfigEnvironmentDevelopment		= @"NSRConfigEnvironmentDevelopment";

--- a/nsrails/Source/NSRPropertyCollection.m
+++ b/nsrails/Source/NSRPropertyCollection.m
@@ -269,7 +269,8 @@
 
 - (NSArray *) objcPropertiesForRemoteEquivalent:(NSString *)remoteProp autoinflect:(BOOL)autoinflect
 {
-	NSString *inflectedRemoteProp = (autoinflect ? [remoteProp camelize] : remoteProp);
+#pragma warning - Altered here!
+	NSString *inflectedRemoteProp = (autoinflect ? remoteProp : remoteProp);
 	
 	NSMutableArray *props = [NSMutableArray array];
 	for (NSString *property in properties)

--- a/nsrails/Source/NSRails.h
+++ b/nsrails/Source/NSRails.h
@@ -30,3 +30,4 @@
 
 #import "NSRConfig.h"
 #import "NSRailsModel.h"
+#import "NSRailsManagedObject.h"

--- a/nsrails/Source/NSRailsManagedObject.h
+++ b/nsrails/Source/NSRailsManagedObject.h
@@ -594,6 +594,8 @@
 
 + (id)findExistingModelWithPrimaryKeyAttributeValue:(id)value;
 + (NSString *)primaryKeyAttributeName;
++ (void)setManagedObjectContext:(NSManagedObjectContext *)context;
++ (void)saveContext;
 
 
 @end

--- a/nsrails/Source/NSRailsManagedObject.h
+++ b/nsrails/Source/NSRailsManagedObject.h
@@ -35,15 +35,16 @@
 @class NSRPropertyCollection;
 
 static NSString *NSRailsSaveCoreDataNotification = @"should_save_core_data";
-static const char contextKey;
 
 /**
  
  ### Summary
  
- `NSRailsModel` is the primary class in NSRails - any classes that inherit from it will be treated with a "remote correspondance" and ActiveResource-like APIs will be available.
-  
- Note that you do not have to define an `id` property for your Objective-C class, as your subclass will inherit `NSRailsModel`'s `remoteID` property. Foreign keys are optional but also unnecessary (see [nesting](https://github.com/dingbat/nsrails/wiki/Nesting) on the NSRails wiki).
+ `NSRailsManagedObject` is the class in NSRails for using CoreData - any classes that inherit from it will be treated with a "remote correspondance" and ActiveResource-like APIs will be available, as well as any methods from its parent class NSManagedObject.
+ This class contains the same methods as its NSRailsModel counterpart. The difference is that inheriting from this class will automatically insert the fetched objects into Core Data using a find-or-create methodology. You must ensure to name the class and its primary key according to the "Model"/"model_id" convention.
+ You must set the managed object context by using the class method setManagedObjectContext: so that NSRails can automatically CRUD Core Data objects when using its ActiveResource-like methods.
+ When the managed object context should be saved, this class will broadcast a notification defined in the NSRailsSaveCoreDataNotification constant. If you are using thread-specific contexts, you should respond to this notification and save the context according to your Core Data thread architecture. It is otherwise safe to disregard this notification.
+ When defining the data model in the *.xcdatamodeld file, you must ensure to set the Class of any entities which inherit from NSRailsManagedObject to the same value as the entity name. Otherwise, Core Data will assume your entity inherits from NSManagedObject rather than from NSRailsManagedObject. If this is not done, your application *will* crash when NSRails attempts to insert new objects.
  
  About this document:
  

--- a/nsrails/Source/NSRailsManagedObject.h
+++ b/nsrails/Source/NSRailsManagedObject.h
@@ -34,7 +34,7 @@
 
 @class NSRPropertyCollection;
 
-static const NSString *NSRailsSaveCoreDataNotification = @"should_save_core_data";
+static NSString *NSRailsSaveCoreDataNotification = @"should_save_core_data";
 
 /**
  

--- a/nsrails/Source/NSRailsManagedObject.h
+++ b/nsrails/Source/NSRailsManagedObject.h
@@ -35,6 +35,7 @@
 @class NSRPropertyCollection;
 
 static NSString *NSRailsSaveCoreDataNotification = @"should_save_core_data";
+static const char contextKey;
 
 /**
  
@@ -594,14 +595,44 @@ static NSString *NSRailsSaveCoreDataNotification = @"should_save_core_data";
  */
 - (id) initWithCustomSyncProperties:(NSString *)str customConfig:(NSRConfig *)config;
 
+/** 
+ Finds a model in Core Data whose primary key attribute is equal to the value passed in. Note that the primary key attribute is assumed to be of the form "classname_id", corresponding to a class named "Classname". 
+ 
+ @param value The value of the primary key attribute. This value will typically be an NSNumber wrapping a positive integer.
+ @return The NSRailsManagedObject from Core Data, if it exists. If it does not exist, this method will create it and return it with its primary key attribute set equal to the value parameter.
+ */
 + (id)findExistingModelWithPrimaryKeyAttributeValue:(id)value;
-+ (NSString *)primaryKeyAttributeName;
-+ (void)setManagedObjectContext:(NSManagedObjectContext *)context;
-+ (void)saveContext;
 
+/**
+ Finds the first object whose specified attribute is equal to the value passed in within the given object context.
+ @param attr_name A property name as a string on the receiver of this method.
+ @param value The desired value of attr_name.
+ @param context The managed object context on which to search for the NSRailsManagedObject
+ @return Returns if found, the first NSRailsManagedObject instance whose attr_name property is equal to value. If not found, this method returns nil. 
+ */
++ (NSRailsManagedObject *)findFirstObjectByAttribute:(NSString *)attr_name withValue:(id)value inContext:(NSManagedObjectContext *)context;
+
+/** 
+ This method takes the class name, lowercases it, then appends "_id" to it. For example, for a class called User, the primary key attribute would be "user_id".
+ @return The primary key attribute of the receiver class. 
+ */
++ (NSString *)primaryKeyAttributeName;
+
+/**
+ This method sets a static NSManagedObjectContext for NSRailsManagedObjects to use for inserting new objects and saving the context. 
+ @param context The desired managed object context.
+ */
++ (void)setManagedObjectContext:(NSManagedObjectContext *)context;
+/**
+ This method will save the statically set managed object context. It also broadcasts the NSNotification named in the NSRailsSaveCoreDataNotification constant, so if thread-specific object contexts are used, responding to this notification will allow the object context for the current thread to be saved (such as when using MagicalRecord to initialize the Core Data stack).
+ */
++ (void)saveContext;
+/**
+ This method will save the object context of the receiver. It also broadcasts the NSNotification named in the NSRailsSaveCoreDataNotification constant, so if thread-specific object contexts are used, responding to this notification will allow the object context for the current thread to be saved (such as when using MagicalRecord to initialize the Core Data stack).
+ */
+- (void)saveContext;
 
 @end
-
 
 
 /// /// /// /// /// /// /// /// /// /// /// /// /// /// /// /// /// /// /// /// /// /// /// /// /

--- a/nsrails/Source/NSRailsManagedObject.h
+++ b/nsrails/Source/NSRailsManagedObject.h
@@ -1,0 +1,678 @@
+/*
+ 
+ _|_|_|    _|_|  _|_|  _|_|  _|  _|      _|_|           
+ _|  _|  _|_|    _|    _|_|  _|  _|_|  _|_| 
+ 
+ NSRails.h
+ 
+ Copyright (c) 2012 Dan Hassin.
+ 
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+ 
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ 
+ */
+
+#import <Foundation/Foundation.h>
+#import <CoreData/CoreData.h>
+#import "NSRConfig.h"
+
+@class NSRPropertyCollection;
+
+/**
+ 
+ ### Summary
+ 
+ `NSRailsModel` is the primary class in NSRails - any classes that inherit from it will be treated with a "remote correspondance" and ActiveResource-like APIs will be available.
+  
+ Note that you do not have to define an `id` property for your Objective-C class, as your subclass will inherit `NSRailsModel`'s `remoteID` property. Foreign keys are optional but also unnecessary (see [nesting](https://github.com/dingbat/nsrails/wiki/Nesting) on the NSRails wiki).
+ 
+ About this document:
+ 
+ - You'll notice that almost all `NSRailsModel` properties and methods are prefixed with `remote`, so you can quickly navigate through them with autocomplete.
+ - When this document refers to an object's "model name", that means (by default) the name of its class. If you wish to define a custom model name (if the name of your model in Rails is distinct from your class name), use the `NSRailsUseModelName()` macro.
+ - Before exploring this document, make sure that your class inherits from `NSRailsModel`, or of course these methods & properties will not be available.
+ 
+ ### Available Macros
+ 
+ - `NSRailsSync()` - define specific properties to be shared with Rails, along with configurable behaviors.
+ - `NSRailsUseModelName()` - define a custom model name for your class, optionally with a custom plural. Takes string literal(s).
+ - `NSRailsUseConfig()` - define a custom app URL for your class, optionally with username/password. Takes string literal(s).
+ 
+ These macros can be defined right inside your subclass's implementation:
+ 
+	@implementation Article  NSRailsUseModelName(@"post")
+	@synthesize title, content;
+	NSRailsSync(title, content)
+	
+	@end
+ 
+ Please see their detailed descriptions on [the NSRails wiki](https://github.com/dingbat/nsrails/wiki/Macros).
+ 
+ ### Validation Errors
+ 
+ If a create or update failed due to validation reasons, NSRails will package the validation failures into a dictionary. This can be retrieved using the key constant `NSRValidationErrorsKey` in the `userInfo` property of the error. This dictionary contains **each failed property as a key**, with each respective object being **an array of the reasons that property failed validation**. For instance,
+ 
+	 NSError *error;
+	 [user createRemote:&error];
+	 if (error)
+	 {
+		 NSDictionary *validationErrors = [[error userInfo] objectForKey:NSRValidationErrorsKey];
+		 
+		 for (NSString *property in validationErrors)
+		 {
+			 for (NSString *reasonForFailure in [validationErrors objectForKey:property])
+			 {
+				 NSLog(@"%@ %@",property,reasonForFailure);
+			 }
+		 }
+	 }
+ 
+ 
+ */
+
+
+@interface NSRailsManagedObject : NSManagedObject <NSCoding>
+{
+	//used if initialized with initWithCustomSyncProperties
+	NSRPropertyCollection *customProperties;
+}
+
+/// =============================================================================================
+/// @name Properties
+/// =============================================================================================
+
+/**
+ The corresponding local property for `id`.
+ 
+ It is notable that this property will be automatically updated after remoteCreate:, as will anything else that is returned from that create.
+ */
+@property (nonatomic, strong) NSNumber *remoteID;
+
+/**
+ The most recent dictionary of all properties returned by Rails, exactly as it returned it. (read-only)
+ 
+ This will include properties that you may not have defined in your Objective-C class, allowing you to dynamically add fields to your app if the server-side model changes.
+ Moreover, this will not take into account anything in NSRailsSync - it is exactly the hash as was sent by Rails.
+ */
+@property (nonatomic, strong, readonly) NSDictionary *remoteAttributes;
+
+/**
+ If true, will remotely destroy this object if sent nested.
+ 
+ If true, this object will include a `_destroy` key on send (ie, when the model nesting it is sent during a remoteUpdate: or remoteCreate:).
+ 
+ This can be useful if you have a lot of nested models you need to destroy - you can do it in one request instead of several repeated destroys on each object.
+ 
+ @warning Relevant for a nested object only. And, for this to work, make sure `:allow_destroy => true` [is set in your Rails model](https://github.com/dingbat/nsrails/wiki/Nesting).
+ */
+@property (nonatomic) BOOL remoteDestroyOnNesting;
+
+
+// =============================================================================================
+/// @name Class requests (Common)
+// =============================================================================================
+
+/**
+ Returns an array of all remote objects (as instances of receiver's class.) Each instance’s properties will be set to those returned by Rails.
+ 
+ Makes a GET request to `/objects.json` (where `objects` is the pluralization of receiver's model name.)
+ 
+ Request done synchronously. See remoteAllAsync: for asynchronous operation.
+ 
+ @param error Out parameter used if an error occurs while processing the request. May be `NULL`.
+ @return NSArray of instances of receiver's class. Each object’s properties will be set to those returned by Rails.
+ */
++ (NSArray *) remoteAll:(NSError **)error;
+
+/**
+ Retrieves an array of all remote objects (as instances of receiver's class.) Each instance’s properties will be set to those returned by Rails.
+ 
+ Asynchronously makes a GET request to `/objects.json` (where `objects` is the pluralization of receiver's model name.)
+  
+ @param completionBlock Block to be executed when the request is complete.
+ */
++ (void) remoteAllAsync:(NSRGetAllCompletionBlock)completionBlock;
+
+
+
+/**
+ Returns an instance of receiver's class corresponding to the remote object with that ID.
+ 
+ Makes a GET request to `/objects/1.json` (where `objects` is the pluralization of receiver's model name, and `1` is *objectID*
+ 
+ )
+ 
+ Request done synchronously. See remoteObjectWithID:async: for asynchronous operation.
+ 
+ @param objectID The ID of the remote object.
+ @param error Out parameter used if an error occurs while processing the request. May be `NULL`.
+ @return Instance of receiver's class with properties from the remote object with that ID.
+ */
++ (id) remoteObjectWithID:(NSInteger)objectID error:(NSError **)error;
+
+/**
+ Retrieves an instance receiver's class corresponding to the remote object with that ID.
+ 
+ Asynchronously makes a GET request to `/objects/1.json` (where `objects` is the pluralization of receiver's model name, and `1` is *objectID*)
+ 
+ @param objectID The ID of the remote object.
+ @param completionBlock Block to be executed when the request is complete.
+ */
++ (void) remoteObjectWithID:(NSInteger)objectID async:(NSRGetObjectCompletionBlock)completionBlock;
+
+
+
+// =============================================================================================
+/// @name Class requests (Custom)
+// =============================================================================================
+
+/**
+ Returns the JSON response for a GET request to a custom method.
+ 
+ Calls remoteRequest:method:body:error: with `GET` for *httpVerb* and `nil` for *body*.
+ 
+ Request done synchronously. See remoteGET:async: for asynchronous operation.
+
+ @param customRESTMethod Custom REST method to be called on the subclass's controller. If `nil`, will route to index.
+ @param error Out parameter used if an error occurs while processing the request. May be `NULL`.
+ @return NSString response (in JSON).
+ */
++ (NSString *) remoteGET:(NSString *)customRESTMethod error:(NSError **)error;
+
+/**
+ Makes a GET request to a custom method.
+ 
+ Calls remoteRequest:method:body:async: with `GET` for *httpVerb* and `nil` for *body*.
+ 
+ @param customRESTMethod Custom REST method to be called on the subclass's controller. If `nil`, will route to index.
+ @param completionBlock Block to be executed when the request is complete.
+ */
++ (void) remoteGET:(NSString *)customRESTMethod async:(NSRHTTPCompletionBlock)completionBlock;
+
+
+
+/**
+ Returns the JSON response for a request with a custom method, sending an `NSRailsModel` subclass instance as the body.
+
+ 
+ Calls remoteRequest:method:body:error: with `obj`'s JSON representation for *body*. (Calls remoteJSONRepresentation on `obj`).
+
+ Request done synchronously. See remoteRequest:method:bodyAsObject:async: for asynchronous operation.
+ 
+ @param httpVerb The HTTP method to use (`GET`, `POST`, `PUT`, `DELETE`, etc.)
+ @param customRESTMethod Custom REST method to be called on the subclass's controller. If `nil`, will route to index.
+ @param obj NSRailsModel subclass instance - object you want to send in the body.
+ @param error Out parameter used if an error occurs while processing the request. May be `NULL`.
+ @return NSString response (in JSON).
+ */
++ (NSString *) remoteRequest:(NSString *)httpVerb method:(NSString *)customRESTMethod bodyAsObject:(NSRailsManagedObject *)obj error:(NSError **)error;
+
+/**
+ Makes a request with a custom method, sending an `NSRailsModel` subclass instance as the body.
+ 
+ Calls remoteRequest:method:body:error: with `obj`'s JSON representation for *body*. (Calls remoteJSONRepresentation on `obj`).
+ 
+ @param httpVerb The HTTP method to use (`GET`, `POST`, `PUT`, `DELETE`, etc.)
+ @param customRESTMethod Custom REST method to be called on the subclass's controller. If `nil`, will route to index.
+ @param obj NSRailsModel subclass instance - object you want to send in the body.
+ @param completionBlock Block to be executed when the request is complete.
+ */
++ (void) remoteRequest:(NSString *)httpVerb method:(NSString *)customRESTMethod bodyAsObject:(NSRailsManagedObject *)obj async:(NSRHTTPCompletionBlock)completionBlock;
+
+
+/**
+ Returns the JSON response for a request with a custom method.
+ 
+ If called on a subclass, makes the request to `/objects/method` (where `objects` is the pluralization of receiver's model name, and `method` is *customRESTMethod*).
+ 
+ If called on `NSRailsModel`, makes the request to `/method` (where `method` is *customRESTMethod*).
+ 
+ `/method` is omitted if `customRESTMethod` is nil.
+ 
+	 [Article remoteRequest:@"POST" method:nil body:json error:&e];           ==> POST /articles.json
+	 [Article remoteRequest:@"POST" method:@"register" body:json error:&e];   ==> POST /articles/register.json
+	 [NSRailsModel remoteGET:@"root" error:&e];                               ==> GET /root.json
+ 
+ Request made synchronously. See remoteRequest:method:body:async: for asynchronous operation.
+ 
+ @param httpVerb The HTTP method to use (`GET`, `POST`, `PUT`, `DELETE`, etc.)
+ @param customRESTMethod The REST method to call (appended to the route). If `nil`, will call index. See above for examples.
+ @param body Request body.
+ @param error Out parameter used if an error occurs while processing the request. May be `NULL`.
+ @return Response string (in JSON).
+ */
++ (NSString *) remoteRequest:(NSString *)httpVerb method:(NSString *)customRESTMethod body:(NSString *)body error:(NSError **)error;
+
+/**
+ Makes a request with a custom method.
+ 
+ If called on a subclass, makes the request to `/objects/method` (where `objects` is the pluralization of receiver's model name, and `method` is *customRESTMethod*).
+ 
+ If called on `NSRailsModel`, makes the request to `/method` (where `method` is *customRESTMethod*).
+ 
+ `/method` is omitted if `customRESTMethod` is nil.
+ 
+	 [Article remoteRequest:@"POST" method:nil body:json async:block];           ==> POST /articles.json
+	 [Article remoteRequest:@"POST" method:@"register" body:json async:block];   ==> POST /articles/register.json
+	 [NSRailsModel remoteRequest:@"GET" method:@"root" body:nil async:block];    ==> GET /root.json
+ 
+ @param httpVerb The HTTP method to use (`GET`, `POST`, `PUT`, `DELETE`, etc.)
+ @param customRESTMethod The REST method to call (appended to the route). If `nil`, will call index. See above for examples.
+ @param body Request body.
+ @param completionBlock Block to be executed when the request is complete.
+ */
++ (void) remoteRequest:(NSString *)httpVerb method:(NSString *)customRESTMethod body:(NSString *)body async:(NSRHTTPCompletionBlock)completionBlock;
+
+/// =============================================================================================
+/// @name Instance requests (CRUD)
+/// =============================================================================================
+
+/**
+ Retrieves the latest remote data for receiver and sets its properties to received response.
+ 
+ Sends a `GET` request to `/objects/1.json` (where `objects` is the pluralization of receiver's model name, and `1` is the receiver's `remoteID`).
+ Request made synchronously. See remoteFetchAsync: for asynchronous operation.
+ 
+ Requires presence of `remoteID`, or will throw an `NSRailsRequiresRemoteIDException`.
+ 
+ @param error Out parameter used if an error occurs while processing the request. May be `NULL`. 
+ @return `YES` if fetch was successful. Returns `NO` if an error occurred.
+ 
+ @see remoteFetch:changes:
+ */
+- (BOOL) remoteFetch:(NSError **)error;
+
+/**
+ Retrieves the latest remote data for receiver and sets its properties to received response.
+ 
+ Sends a `GET` request to `/objects/1.json` (where `objects` is the pluralization of receiver's model name, and `1` is the receiver's `remoteID`).
+ Request made synchronously. See remoteFetchAsync: for asynchronous operation.
+ 
+ Requires presence of `remoteID`, or will throw an `NSRailsRequiresRemoteIDException`.
+ 
+ @param error Out parameter used if an error occurs while processing the request. May be `NULL`. 
+ @param changesPtr Pointer to boolean value set to whether or not the receiver changed in any way after the fetch (ie, if this fetch modified one of receiver's local properties due to a change in value server-side). This will also take into account diffs to any nested `NSRailsModel` objects that are affected by this fetch (done recursively).
+ 
+ Note that because this only tracks differences in local changes, properties that changed server-side that are not defined in the receiver's class will *not* report back a change (ie, if receiver's class doesn't implement an `updated_at` property and `updated_at` is changed in your remote DB, no change will be reported.) This parameter may be `NULL` if this information is not useful, or use remoteFetch:.
+ @return `YES` if fetch was successful. Returns `NO` if an error occurred.
+ 
+ @see remoteFetch:
+ */
+- (BOOL) remoteFetch:(NSError **)error changes:(BOOL *)changesPtr;
+
+
+/**
+ Retrieves the latest remote data for receiver and sets its properties to received response.
+ 
+ Asynchronously sends a `GET` request to `/objects/1.json` (where `objects` is the pluralization of receiver's model name, and `1` is the receiver's `remoteID`).
+ 
+ Requires presence of `remoteID`, or will throw an `NSRailsRequiresRemoteIDException`.
+
+ @param completionBlock Block to be executed when the request is complete. The second parameter passed in is a BOOL whether or not there was a *local* change. This means changes in `updated_at`, etc, will only apply if your Objective-C class implement this as a property as well. This also applies when updating any of its nested objects (done recursively).
+ */
+- (void) remoteFetchAsync:(NSRGetLatestCompletionBlock)completionBlock;
+
+
+/**
+ Updates receiver's corresponding remote object.
+ 
+ Sends an `UPDATE` request to `/objects/1.json` (where `objects` is the pluralization of receiver's model name, and `1` is the receiver's `remoteID`).
+ Request made synchronously. See remoteUpdateAsync: for asynchronous operation.
+
+ Requires presence of `remoteID`, or will throw an `NSRailsRequiresRemoteIDException`.
+ 
+ @param error Out parameter used if an error occurs while processing the request. May be `NULL`.
+ @return `YES` if update was successful. Returns `NO` if an error occurred.
+
+ @warning No local properties will be set, as Rails does not return anything for this action. This means that if you update an object with the creation of new nested objects, those nested objects will not locally update with their respective IDs.
+ */
+- (BOOL) remoteUpdate:(NSError **)error;
+
+/**
+ Updates receiver's corresponding remote object.
+ 
+ Asynchronously sends an `UPDATE` request to `/objects/1.json` (where `objects` is the pluralization of receiver's model name, and `1` is the receiver's `remoteID`).
+ 
+ Requires presence of `remoteID`, or will throw an `NSRailsRequiresRemoteIDException`.
+ 
+ @param completionBlock Block to be executed when the request is complete.
+ 
+ @warning No local properties will be set, as Rails does not return anything for this action. This means that if you update an object with the creation of new nested objects, those nested objects will not locally update with their respective IDs.
+ */
+- (void) remoteUpdateAsync:(NSRBasicCompletionBlock)completionBlock;
+
+
+/**
+ Creates the receiver remotely. Receiver's properties will be set to those given by Rails (including `remoteID`).
+ 
+ Sends a `POST` request to `/objects.json` (where `objects` is the pluralization of receiver's model name), with the receiver's remoteJSONRepresentation as its body.
+ Request made synchronously. See remoteCreateAsync: for asynchronous operation.
+
+ @param error Out parameter used if an error occurs while processing the request. May be `NULL`.
+ @return `YES` if create was successful. Returns `NO` if an error occurred.
+ */
+- (BOOL) remoteCreate:(NSError **)error;
+
+/**
+ Creates the receiver remotely. Receiver's properties will be set to those given by Rails (including `remoteID`).
+ 
+ Asynchronously sends a `POST` request to `/objects.json` (where `objects` is the pluralization of receiver's model name), with the receiver's remoteJSONRepresentation as its body.
+ 
+ @param completionBlock Block to be executed when the request is complete.
+ */
+- (void) remoteCreateAsync:(NSRBasicCompletionBlock)completionBlock;
+
+
+
+/**
+ Destroys receiver's corresponding remote object. Local object will be unaffected.
+ 
+ Sends a `DELETE` request to `/objects/1.json` (where `objects` is the pluralization of receiver's model name, and `1` is the receiver's `remoteID`).
+ Request made synchronously. See remoteDestroyAsync: for asynchronous operation.
+ 
+ @param error Out parameter used if an error occurs while processing the request. May be `NULL`.
+ @return `YES` if destroy was successful. Returns `NO` if an error occurred.
+ */
+- (BOOL) remoteDestroy:(NSError **)error;
+
+/**
+ Destroys receiver's corresponding remote object. Local object will be unaffected.
+ 
+ Asynchronously sends a `DELETE` request to `/objects/1.json` (where `objects` is the pluralization of receiver's model name, and `1` is the receiver's `remoteID`).
+ 
+ @param completionBlock Block to be executed when the request is complete.
+ */
+- (void) remoteDestroyAsync:(NSRBasicCompletionBlock)completionBlock;
+
+
+/// =============================================================================================
+/// @name Instance requests (Custom)
+/// =============================================================================================
+
+/**
+ Returns the JSON response for a GET request to a custom method.
+ 
+ Calls remoteRequest:method:body:error: with `GET` for *httpVerb* and `nil` for *body*.
+ 
+ Request done synchronously. See remoteGET:async: for asynchronous operation.
+ 
+ @param customRESTMethod Custom REST method to be called on the remote object corresponding to the receiver. If `nil`, will route to only the receiver (objects/1.json).
+ @param error Out parameter used if an error occurs while processing the request. May be `NULL`.
+ @return NSString response (in JSON).
+ */
+- (NSString *) remoteGET:(NSString *)customRESTMethod error:(NSError **)error;
+
+/**
+ Makes a GET request to a custom method.
+ 
+ Calls remoteRequest:method:body:async: with `GET` for *httpVerb* and `nil` for *body*.
+ 
+ @param customRESTMethod Custom REST method to be called on the remote object corresponding to the receiver. If `nil`, will route to only the receiver (objects/1.json).
+ @param completionBlock Block to be executed when the request is complete.
+ */
+- (void) remoteGET:(NSString *)customRESTMethod async:(NSRHTTPCompletionBlock)completionBlock;
+
+
+/**
+ Returns the JSON response for a request with a custom method, sending the JSON representation of the receiver as the request body.
+ 
+ Calls remoteRequest:method:body:error: with `obj`'s JSON representation for *body*. (Calls remoteJSONRepresentation on `obj`).
+ 
+ Request done synchronously. See remoteRequest:method:bodyAsObject:async: for asynchronous operation.
+ 
+ @param httpVerb The HTTP method to use (`GET`, `POST`, `PUT`, `DELETE`, etc.)
+ @param customRESTMethod Custom REST method to be called on the remote object corresponding to the receiver. If `nil`, will route to only the receiver (objects/1.json).
+ @param error Out parameter used if an error occurs while processing the request. May be `NULL`.
+ @return NSString response (in JSON).
+ */
+- (NSString *) remoteRequest:(NSString *)httpVerb method:(NSString *)customRESTMethod error:(NSError **)error;
+
+/**
+ Makes a request with a custom method, sending the JSON representation of the receiver as the request body.
+ 
+ Calls remoteRequest:method:body:async: with receiver's JSON representation for *body*. (Calls remoteJSONRepresentation).
+ 
+ @param httpVerb The HTTP method to use (`GET`, `POST`, `PUT`, `DELETE`, etc.)
+ @param customRESTMethod Custom REST method to be called on the remote object corresponding to the receiver. If `nil`, will route to only the receiver (objects/1.json).
+ @param completionBlock Block to be executed when the request is complete.
+ */
+- (void) remoteRequest:(NSString *)httpVerb method:(NSString *)customRESTMethod async:(NSRHTTPCompletionBlock)completionBlock;
+
+
+/**
+ Returns the JSON response for a request with a custom method on the receiver's corresponding remote object.
+ 
+ Makes a request to `/objects/1/method` (where `objects` is the pluralization of receiver's model name, `1` is the receiver's `remoteID`, and `method` is *customRESTMethod*).
+  
+ `/method` is omitted if `customRESTMethod` is nil.
+ 
+	[myArticle remoteRequest:@"PUT" method:nil body:json error:&e];           ==> PUT /articles/1.json
+	[myArticle remoteRequest:@"PUT" method:@"register" body:json error:&e];   ==> PUT /articles/1/register.json
+ 
+ Request made synchronously. See remoteRequest:method:body:async: for asynchronous operation.
+ 
+ @param httpVerb The HTTP method to use (`GET`, `POST`, `PUT`, `DELETE`, etc.)
+ @param customRESTMethod The REST method to call (appended to the route). If `nil`, will call index. See above for examples.
+ @param body Request body.
+ @param error Out parameter used if an error occurs while processing the request. May be `NULL`.
+ @return Response string (in JSON).
+ */
+- (NSString *) remoteRequest:(NSString *)httpVerb method:(NSString *)customRESTMethod body:(NSString *)body error:(NSError **)error;
+
+/**
+ Makes a request with a custom method on the receiver's corresponding remote object.
+ 
+ Asynchronously akes a request to `/objects/1/method` (where `objects` is the pluralization of receiver's model name, `1` is the receiver's `remoteID`, and `method` is *customRESTMethod*).
+  
+ `/method` is omitted if `customRESTMethod` is nil.
+ 
+	[myArticle remoteRequest:@"PUT" method:nil body:json error:&e];           ==> PUT /articles/1.json
+	[myArticle remoteRequest:@"PUT" method:@"register" body:json error:&e];   ==> PUT /articles/1/register.json
+ 
+ @param httpVerb The HTTP method to use (`GET`, `POST`, `PUT`, `DELETE`, etc.)
+ @param customRESTMethod The REST method to call (appended to the route). If `nil`, will call index. See above for examples.
+ @param body Request body.
+ @param completionBlock Block to be executed when the request is complete.
+ */
+- (void) remoteRequest:(NSString *)httpVerb method:(NSString *)customRESTMethod body:(NSString *)body async:(NSRHTTPCompletionBlock)completionBlock;
+
+
+
+/// =============================================================================================
+/// @name Manual JSON encoding/decoding
+/// =============================================================================================
+
+
+/**
+ Serializes the receiver's properties into a JSON string.
+ 
+ Encapsulates the data with a key of the model name:
+	{"user"=>{"name"=>"x", "email"=>"y"}}
+
+ 
+ @return The receiver's properties as a JSON string (takes into account rules in NSRailsSync).
+ */
+- (NSString *) remoteJSONRepresentation;
+
+/**
+ Serializes the receiver's properties into a dictionary.
+ 
+ Does not encapsulate as remoteJSONRepresentation does.
+ 
+ @return The receiver's properties as a dictionary (takes into account rules in NSRailsSync).
+ */
+- (NSDictionary *) dictionaryOfRemoteProperties;
+
+/**
+ Sets the receiver's properties given a JSON string.
+ 
+ Takes into account rules in NSRailsSync.
+ 
+ @param json JSON string to be evaluated, typically from the Rails output from a previous request. 
+ @return YES if any changes were made to the local object, NO if object was identical before/after.
+ */
+- (BOOL) setPropertiesUsingRemoteJSON:(NSString *)json;
+
+/**
+ Sets the receiver's properties given a dictionary.
+ 
+ Takes into account rules in NSRailsSync.
+ 
+ @param dictionary Dictionary to be evaluated. 
+ @return YES if any changes were made to the local object, NO if object was identical before/after.
+ */
+- (BOOL) setPropertiesUsingRemoteDictionary:(NSDictionary *)dictionary;
+
+/// =============================================================================================
+/// @name Initializers
+/// =============================================================================================
+
+
+/**
+ Initializes a new instance of the receiver's class with a given JSON input.
+ 
+ Takes into account rules in NSRailsSync.
+ 
+ @param json JSON string to be evaluated, typically from the Rails output from a previous request. 
+ @return YES if any changes were made to the local object, NO if object was identical before/after.
+ */
+- (id) initWithRemoteJSON:(NSString *)json;
+
+/**
+ Initializes a new instance of the receiver's class with a given dictionary input.
+ 
+ Takes into account rules in NSRailsSync.
+ 
+ @param dictionary Dictionary to be evaluated. 
+ @return YES if any changes were made to the local object, NO if object was identical before/after.
+ */
+- (id) initWithRemoteDictionary:(NSDictionary *)dictionary;
+
+/**
+ Initializes a new instance of the receiver's class with a custom NSRailsSync string.
+ 
+ The given NSRailsSync string will be used only for this **instance**. This instance will not use its class's NSRailsSync. This is very uncommon and triple checking is recommended before going with this implementation strategy.
+ 
+ Pass in a string as you would type it into NSRailsSync():
+	Person *zombie = [[Person alloc] initWithCustomSyncProperties:@"*, brain -x"];
+
+ 
+ @param str String to become this instance's NSRailsSync - pass as you would an NSRailsSync string (see above). 
+ @return YES if any changes were made to the local object, NO if object was identical before/after.
+ */
+- (id) initWithCustomSyncProperties:(NSString *)str;
+
+/**
+ Initializes a new instance of the receiver's class with a custom NSRailsSync string and config.
+ 
+ The given NSRailsSync string and config will be used only for this **instance**. This instance will not use its class's NSRailsSync or NSRailsUseConfig or any default configs (although any config in a context block (with use or useIn) will take precedence). This is very uncommon and triple checking is recommended before going with this implementation strategy.
+ 
+ Pass in a string as you would type it into NSRailsSync():
+	Person *zombie = [[Person alloc] initWithCustomSyncProperties:@"*, brain -x" customConfig:nonInflectingConfig];
+ 
+ @param str String to become this instance's NSRailsSync - pass as you would an NSRailsSync string (see above).  
+ @param config Config to become this instance's config. 
+ @return YES if any changes were made to the local object, NO if object was identical before/after.
+ */
+- (id) initWithCustomSyncProperties:(NSString *)str customConfig:(NSRConfig *)config;
+
++ (id)findExistingModelWithPrimaryKeyAttributeValue:(id)value;
++ (NSString *)primaryKeyAttributeName;
+
+
+@end
+
+
+
+/// /// /// /// /// /// /// /// /// /// /// /// /// /// /// /// /// /// /// /// /// /// /// /// /
+/// =============================================================================================
+#pragma mark - Macro definitions
+/// =============================================================================================
+/// /// /// /// /// /// /// /// /// /// /// /// /// /// /// /// /// /// /// /// /// /// /// /// /
+
+
+/// =============================================================================================
+#pragma mark - Helpers
+/// =============================================================================================
+
+//clever macro trick to allow "overloading" macro functions thanks to orj's gist: https://gist.github.com/985501
+#define _CAT(a, b) _PRIMITIVE_CAT(a, b)
+#define _PRIMITIVE_CAT(a, b) a##b
+#define _N_ARGS(...) _N_ARGS_1(__VA_ARGS__, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0)
+#define _N_ARGS_1(...) _N_ARGS_2(__VA_ARGS__)
+#define _N_ARGS_2(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, n, ...) n
+
+//macro to convert cstring to NSString
+#define NSRStringFromCString(cstr)	[NSString stringWithCString:cstr encoding:NSUTF8StringEncoding]
+
+//adding a # before va_args will simply make its contents a cstring
+#define _MAKE_STR(...)	NSRStringFromCString(#__VA_ARGS__)
+
+
+/// =============================================================================================
+#pragma mark NSRailsSync
+/// =============================================================================================
+
+//define NSRailsSync to create a method called NSRailsSync, which returns the entire param list
+#define NSRailsSync(...) \
++ (NSString*) NSRailsSync { return _MAKE_STR(__VA_ARGS__); }
+
+//define NSRNoCarryFromSuper as NSRNoCarryFromSuper - not a string, since it's placed directly in the macro
+#define NSRNoCarryFromSuper			NSRNoCarryFromSuper
+
+//returns the string version of NSRNoCarryFromSuper so we can find it when evaluating NSRailsSync string
+#define _NSRNoCarryFromSuper_STR	_MAKE_STR(NSRNoCarryFromSuper)
+
+
+/// =============================================================================================
+#pragma mark NSRailsUseModelName
+/// =============================================================================================
+
+//define NSRailsUseModelName to concat either _NSR_Name1(x) or _NSR_Name2(x,y), depending on the number of args passed in
+#define NSRailsUseModelName(...) _CAT(_NSR_Name,_N_ARGS(__VA_ARGS__))(__VA_ARGS__)
+
+//using default is the same thing as passing nil for both model name + plural name
+#define NSRailsUseDefaultModelName _NSR_Name2(nil,nil)
+
+//_NSR_Name1 (only with 1 parameter, ie, custom model name but default plurality), creates NSRailsUseModelName method that returns param, return nil for plural to make it go to default
+#define _NSR_Name1(name)	_NSR_Name2(name, nil)
+
+//_NSR_Name2 (2 parameters, ie, custom model name and custom plurality), creates NSRailsUseModelName and NSRailsUsePluralName
+#define _NSR_Name2(name,plural)  \
++ (NSString*) NSRailsUseModelName { return name; } \
++ (NSString*) NSRailsUsePluralName { return plural; }
+
+
+/// =============================================================================================
+#pragma mark NSRailsUseConfig
+/// =============================================================================================
+
+//works the same way as NSRailsUseModelName
+
+#define NSRailsUseConfig(...) _CAT(_NSR_Config,_N_ARGS(__VA_ARGS__))(__VA_ARGS__)
+
+#define NSRailsUseDefaultConfig	_NSR_Config3(nil, nil, nil)
+
+#define _NSR_Config1(url)	_NSR_Config3(url, nil, nil)
+
+#define _NSR_Config3(url,user,pass)  \
++ (NSString *) NSRailsUseConfigURL { return url; } \
++ (NSString *) NSRailsUseConfigUsername { return user; } \
++ (NSString *) NSRailsUseConfigPassword { return pass; }
+

--- a/nsrails/Source/NSRailsManagedObject.h
+++ b/nsrails/Source/NSRailsManagedObject.h
@@ -34,6 +34,8 @@
 
 @class NSRPropertyCollection;
 
+static const NSString *NSRailsSaveCoreDataNotification = @"should_save_core_data";
+
 /**
  
  ### Summary

--- a/nsrails/Source/NSRailsManagedObject.m
+++ b/nsrails/Source/NSRailsManagedObject.m
@@ -876,7 +876,11 @@ NSRailsSync(*);
 
 - (BOOL) remoteUpdate:(NSError **)error
 {
-	return !![self remoteRequest:@"PUT" method:nil error:error];
+	BOOL didUpdate = !![self remoteRequest:@"PUT" method:nil error:error];
+  if (*error == nil) {
+    [self saveContext];
+  }
+  return didUpdate;
 }
 
 - (void) remoteUpdateAsync:(NSRBasicCompletionBlock)completionBlock
@@ -884,6 +888,9 @@ NSRailsSync(*);
 	[self remoteRequest:@"PUT" method:nil async:
 	 
 	 ^(NSString *result, NSError *error) {
+     if (error == nil) {
+       [self saveContext];
+     }
 		 completionBlock(error);
 	 }];
 }

--- a/nsrails/Source/NSRailsManagedObject.m
+++ b/nsrails/Source/NSRailsManagedObject.m
@@ -1145,24 +1145,21 @@ NSRailsSync(*);
 + (void)saveContext {
   dispatch_async(dispatch_get_main_queue(), ^{
     NSManagedObjectContext *ctx = _context;
-    while (ctx.parentContext != nil) {
-      @try {
-        [ctx performBlockAndWait:^{
-          NSError *error = nil;
-          if (![ctx save:&error]) {
-            NSLog(@"Failed to save core data: %@", [error localizedDescription]);
-          } else {
-            NSLog(@"\"Successfully\" saved your data.");
-          }
-        }];
-      }
-      @catch (NSException *exception) {
-        NSLog(@"Couldn't save your data! Try again later :(");
-      }
-      @finally {
-        NSLog(@"Look, I don't know what else to tell you, mang.");
-        ctx = ctx.parentContext;
-      }
+    @try {
+      [ctx performBlockAndWait:^{
+        NSError *error = nil;
+        if (![ctx save:&error]) {
+          NSLog(@"NSRailsManagedObject class %@: failed to save core data with error: %@", NSStringFromClass([self class]), [error localizedDescription]);
+        } else {
+          NSLog(@"NSRailsManagedObject class %@: successfully saved core data!", NSStringFromClass([self class]));
+        }
+      }];
+    }
+    @catch (NSException *exception) {
+      NSLog(@"NSRailsManagedObject class %@ triggered an exception when trying to save core data: %@", NSStringFromClass([self class]), [exception reason]);
+    }
+    @finally {
+      
     }
   });
     [[NSNotificationCenter defaultCenter] postNotificationName:NSRailsSaveCoreDataNotification object:nil];
@@ -1173,16 +1170,15 @@ NSRailsSync(*);
     @try {
         NSError *error = nil;
         if (![self.managedObjectContext save:&error]) {
-          NSLog(@"Failed to save core data: %@", [error localizedDescription]);
+          NSLog(@"NSRailsManagedObject instance %@: failed to save core data with error: %@", NSStringFromClass([self class]), [error localizedDescription]);
         } else {
-          NSLog(@"\"Successfully\" saved your data.");
+          NSLog(@"NSRailsManagedObject instance %@: successfully saved core data!", NSStringFromClass([self class]));
         }
     }
     @catch (NSException *exception) {
-      NSLog(@"Couldn't save your data! Try again later :(");
+      NSLog(@"NSRailsManagedObject instance (%@) triggered an exception when trying to save core data: %@", NSStringFromClass([self class]), [exception reason]);
     }
     @finally {
-      NSLog(@"Look, I don't know what else to tell you, mang.");
     }
   });
   [[NSNotificationCenter defaultCenter] postNotificationName:NSRailsSaveCoreDataNotification object:nil];

--- a/nsrails/Source/NSRailsManagedObject.m
+++ b/nsrails/Source/NSRailsManagedObject.m
@@ -1150,7 +1150,7 @@ NSRailsSync(*);
 //  if (error) {
 //    NSLog(@"Failed to save core data: %@", [error localizedDescription]);
 //  }
-    [[NSNotificationCenter defaultCenter] postNotificationName:(NSString *)NSRailsSaveCoreDataNotification object:nil];
+    [[NSNotificationCenter defaultCenter] postNotificationName:NSRailsSaveCoreDataNotification object:nil];
 }
 
 - (void)saveContext {
@@ -1160,7 +1160,7 @@ NSRailsSync(*);
 //  if (error) {
 //    NSLog(@"Failed to save core data: %@", [error localizedDescription]);
 //  }  
-  [[NSNotificationCenter defaultCenter] postNotificationName:(NSString *)NSRailsSaveCoreDataNotification object:nil];
+  [[NSNotificationCenter defaultCenter] postNotificationName:NSRailsSaveCoreDataNotification object:nil];
 }
 
 - (void)awakeFromFetch {

--- a/nsrails/Source/NSRailsManagedObject.m
+++ b/nsrails/Source/NSRailsManagedObject.m
@@ -510,7 +510,7 @@ NSRailsSync(*);
 			{
 				if (railsObject)
 				{
-					if (property.isHasMany && property.nestedClass)
+					if ([railsObject isKindOfClass:[NSArray class]])
 					{
 						if (![railsObject isKindOfClass:[NSArray class]])
 							[NSException raise:NSRailsInternalError format:@"Attempt to set property '%@' in class '%@' (declared as has-many) to a non-array non-null value ('%@').", property, self.class, railsObject];
@@ -548,6 +548,7 @@ NSRailsSync(*);
 								if (!previousVal || idx == NSNotFound)
 								{
 									//didn't previously exist - make a new one
+                  property.nestedClass = [[[railsElement allKeys] objectAtIndex:0] capitalizedString];
 									decodedElement = [self makeRelevantModelFromClass:property.nestedClass basedOn:railsElement];
 									
 									changes = YES;

--- a/nsrails/Source/NSRailsManagedObject.m
+++ b/nsrails/Source/NSRailsManagedObject.m
@@ -1,0 +1,1104 @@
+/*
+ 
+ _|_|_|    _|_|  _|_|  _|_|  _|  _|      _|_|           
+ _|  _|  _|_|    _|    _|_|  _|  _|_|  _|_| 
+ 
+ NSRails.m
+ 
+ Copyright (c) 2012 Dan Hassin.
+ 
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+ 
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ 
+ */
+
+#import "NSRailsModel.h"
+#import "NSRailsManagedObject.h"
+
+#import "NSRPropertyCollection.h"
+#import "NSRConfig.h"
+
+#import "NSString+Inflection.h"
+#import "NSData+Additions.h"
+#import "NSObject+Properties.h"
+#import "SBJson.h"
+#import "UIApplication+MOC.h"
+
+/* 
+    If this file is too intimidating, 
+ remember that you can navigate it
+ quickly in Xcode using #pragma marks.
+								    	*/
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+@interface NSRailsManagedObject (internal)
+
++ (NSRConfig *) getRelevantConfig;
+- (NSRConfig *) getRelevantConfig;
+
++ (NSRPropertyCollection *) propertyCollection;
+- (NSRPropertyCollection *) propertyCollection;
+
+@end
+
+@interface NSRConfig (override)
+
++ (NSRConfig *) overrideConfig;
+
+@end
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+@implementation NSRailsManagedObject
+@synthesize remoteID, remoteDestroyOnNesting, remoteAttributes;
+
+#pragma mark - Meta-NSR stuff
+
+//this will suppress the compiler warnings that come with ARC when doing performSelector
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+
+
+// Use default config + model name by default
+NSRailsUseDefaultModelName;
+NSRailsUseDefaultConfig;
+
+// If NSRailsSync isn't overriden (ie, if NSRailsSync() macro is not declared in subclass), default to *
+NSRailsSync(*);
+
+
+//returns the sync string expanded (* => all properties) & inherited (adds NSRailsSyncs from superclasses)
+//override string is in case there's a custom sync string defined
++ (NSString *) masterNSRailsSyncWithOverrideString:(NSString *)override
+{
+	//base case
+	if (self == [NSRailsManagedObject class])
+		return @"remoteID=id";
+	
+	NSString *syncStr = (override ? override : [self NSRailsSync]);	
+	if ([syncStr rangeOfString:@"*"].location != NSNotFound)
+	{
+		syncStr = [syncStr stringByReplacingOccurrencesOfString:@"*" withString:@""];
+
+		//expand the star to everything in the class
+		NSString *expanded = [self.allProperties componentsJoinedByString:@", "];
+		if (expanded)
+		{
+			//properties need to be appended to existing sync string since they can be overridden like with -x (and stripped of *)
+			syncStr = [syncStr stringByAppendingFormat:@", %@", expanded];
+		}
+	}
+	
+	if ([syncStr rangeOfString:_NSRNoCarryFromSuper_STR].location != NSNotFound)
+	{
+		syncStr = [syncStr stringByReplacingOccurrencesOfString:_NSRNoCarryFromSuper_STR withString:@""];
+
+		//skip right up the hierarchy to NSRailsModel
+		return [syncStr stringByAppendingFormat:@", %@", [NSRailsManagedObject masterNSRailsSyncWithOverrideString:nil]];
+	}
+	
+	//traverse up the hierarchy (always getting the default NSRailsSync)
+	return [syncStr stringByAppendingFormat:@", %@", [self.superclass masterNSRailsSyncWithOverrideString:nil]];
+}
+
++ (NSString *) masterNSRailsSync
+{
+	return [self masterNSRailsSyncWithOverrideString:nil];
+}
+
++ (NSRConfig *) masterClassConfig
+{
+	//check for a custom config for the class
+	
+	NSString *url = [self NSRailsUseConfigURL];
+	if (url)
+	{
+		NSRConfig *custom = [[NSRConfig alloc] initWithAppURL:url];
+		custom.appUsername = [self NSRailsUseConfigUsername];
+		custom.appPassword = [self NSRailsUseConfigPassword];
+		
+		return custom;
+	}
+	
+	return nil;
+}
+
++ (NSString *) masterModelName
+{
+	if (self == [NSRailsModel class])
+		return nil;
+	
+	NSString *defined = [self NSRailsUseModelName];
+	if (defined)
+		return defined;
+	
+	//otherwise, return name of the class
+	NSString *class = NSStringFromClass(self);
+	
+	if ([self getRelevantConfig].autoinflectsClassNames)
+	{
+		return [class underscoreIgnorePrefix:[self getRelevantConfig].ignoresClassPrefixes];
+	}
+	else
+	{
+		return class;
+	}
+}
+
++ (NSString *) masterPluralName
+{
+	NSString *defined = [self NSRailsUsePluralName];
+	if (defined)
+		return defined;
+
+	//otherwise, pluralize ModelName
+	return [[self masterModelName] pluralize];
+}
+
++ (NSRPropertyCollection *) propertyCollection
+{
+	__strong static NSMutableDictionary *propertyCollections = nil;
+	static dispatch_once_t onceToken;
+	
+	//singleton initializer
+    dispatch_once(&onceToken, ^{
+		propertyCollections = [[NSMutableDictionary alloc] init];
+    });
+		
+	NSString *class = NSStringFromClass(self);
+	NSRPropertyCollection *collection = [propertyCollections objectForKey:class];
+	if (!collection)
+	{
+		collection = [[NSRPropertyCollection alloc] initWithClass:self 
+													   syncString:[self masterNSRailsSync] 
+													 customConfig:[self masterClassConfig]];
+		
+		[propertyCollections setObject:collection forKey:class];
+	}
+	
+	return collection;
+}
+
+- (NSRPropertyCollection *) propertyCollection
+{
+	if (customProperties)
+		return customProperties;
+	
+	return [[self class] propertyCollection];
+}
+
++ (NSRConfig *) getRelevantConfigFromPropertyCollection:(NSRPropertyCollection *)propertyCollection
+{	
+	//if there's an overriding config in this context (an -[NSRConfig use] was called (explicitly or implicity via a block))
+	if ([NSRConfig overrideConfig])
+	{
+		return [NSRConfig overrideConfig];
+	}
+	
+	//if this class/instance defines NSRailsUseConfig, use it over the default
+	else if (propertyCollection.customConfig)
+	{
+		return propertyCollection.customConfig;
+	}
+	
+	//otherwise, use the default config
+	else
+	{
+		return [NSRConfig defaultConfig];
+	}
+}
+
++ (NSRConfig *) getRelevantConfig
+{
+	return [self getRelevantConfigFromPropertyCollection:[self propertyCollection]];
+}
+
+- (NSRConfig *) getRelevantConfig
+{
+	if (!customProperties)
+		return [[self class] getRelevantConfig];
+	
+	return [[self class] getRelevantConfigFromPropertyCollection:customProperties];
+}
+
+
+- (id) initWithCustomSyncProperties:(NSString *)str customConfig:(NSRConfig *)config
+{
+  NSManagedObjectContext *ctx = [NSManagedObjectContext MR_defaultContext];
+  NSEntityDescription *desc = [NSEntityDescription entityForName:[[self class] description] inManagedObjectContext:ctx];
+  
+  self = [[NSRailsManagedObject alloc] initWithEntity:desc insertIntoManagedObjectContext:ctx];
+	if (self)
+	{
+		//apply inheritance rules etc to the given string
+		str = [[self class] masterNSRailsSyncWithOverrideString:str];
+		
+		customProperties = [[NSRPropertyCollection alloc] initWithClass:[self class] 
+															 syncString:str 
+														   customConfig:config];
+	}
+	return self;
+}
+
+- (id) initWithCustomSyncProperties:(NSString *)str
+{
+	self = [self initWithCustomSyncProperties:str customConfig:nil];
+	return self;
+}
+
+
+
+#pragma mark - Internal NSR stuff
+
+// Encode/decode date objects by default (will be added as custom en/de coders if they aren't declared)
+
+- (NSString *) nsrails_encodeDate:(NSDate *)date
+{
+	return [[self getRelevantConfig] stringFromDate:date];
+}
+
+- (NSDate *) nsrails_decodeDate:(NSString *)dateRep
+{
+	return [[self getRelevantConfig] dateFromString:dateRep];
+}
+
+//will turn it into a JSON string
+//includes any nested models (which the json framework can't do)
+- (NSString *) remoteJSONRepresentation
+{
+	// enveloped meaning with the model name out front, {"user"=>{"name"=>"x", "password"=>"y"}}
+	
+	NSDictionary *enveloped = [NSDictionary dictionaryWithObject:[self dictionaryOfRemoteProperties]
+														  forKey:[[self class] masterModelName]];
+	
+	NSString *json = [enveloped JSONRepresentation];
+	if (!json)
+	{
+		[NSException raise:NSRailsJSONParsingException format:@"Failed trying to encode instance of %@ to JSON (trying to parse dictionary %@)", self.class, enveloped];
+	}
+	return json;
+}
+
+// override SBJson's category to use the remoteJSON
+- (NSString *) JSONRepresentation
+{
+	return [self remoteJSONRepresentation];
+}
+
+// Helper method for when mapping nested properties to JSON
+- (NSRailsManagedObject *) makeRelevantModelFromClass:(NSString *)classN basedOn:(NSDictionary *)dict
+{
+#pragma warning - "Altered here"
+	//make a new class to be entered for this property/array (we can assume it subclasses NSRailsModel)
+	NSRailsManagedObject *model = [[NSClassFromString(classN) alloc] initWithRemoteDictionary:dict];
+	
+	//see if we can assign an association to its parent (self)
+	NSString *parentModelName = [[self class] masterModelName];
+	NSArray *properties = [[model propertyCollection] objcPropertiesForRemoteEquivalent:parentModelName 
+																			autoinflect:[self getRelevantConfig].autoinflectsPropertyNames];
+	
+	for (NSRProperty *property in properties)
+	{
+		//only assign me to the child if it has me defined as a property and it's marked as nested to me
+		if (property.retrievable &&
+			[property.nestedClass isEqualToString:[self.class description]])
+		{
+			SEL setter = [[model class] setterForProperty:property.name];
+			[model performSelector:setter withObject:self];
+		}
+	}
+	
+	return model;
+}
+
+- (id) remoteRepresentationOfObjectForProperty:(NSRProperty *)prop
+{
+	SEL encoder = NULL;
+	if (prop.encodable)
+	{
+		encoder = NSSelectorFromString([NSString stringWithFormat:@"encode%@", [prop.name firstLetterCapital]]);
+	}
+	else if (prop.isDate)
+	{
+		encoder = @selector(nsrails_encodeDate:);
+	}
+	
+	SEL getter = [self.class getterForProperty:prop.name];
+
+	if (encoder)
+	{
+		id obj = [self respondsToSelector:getter] ? [self performSelector:getter] : nil;
+		
+		//perform selector with the object itself in case it takes it
+		id representation = [self performSelector:encoder withObject:obj];
+
+		//send back an NSNull object instead of nil since we'll be encoding it into JSON, where that's relevant
+		if (!representation)
+		{
+			return [NSNull null];
+		}
+		
+		BOOL JSONParsable = ([representation isKindOfClass:[NSArray class]] ||
+							 [representation isKindOfClass:[NSDictionary class]] ||
+							 [representation isKindOfClass:[NSString class]] ||
+							 [representation isKindOfClass:[NSNumber class]] ||
+							 [representation isKindOfClass:[NSNull class]]);
+		
+		//make sure that the result is a JSON parsable
+		if (!JSONParsable)
+		{
+			[NSException raise:NSRailsJSONParsingException format:@"Trying to encode property '%@' in class '%@', but the result from %@ was not JSON-parsable. Please make sure you return NSDictionary, NSArray, NSString, NSNumber, or NSNull here. Remember, these are the values you want to send in the JSON to Rails. Also, defining this encoder method will override the automatic NSDate translation.",prop, NSStringFromClass([self class]),NSStringFromSelector(encoder)];
+			return nil;
+		}
+		
+		return representation;
+	}
+	else
+	{
+		id val = [self performSelector:getter];
+		BOOL isArray = [val isKindOfClass:[NSArray class]];
+		
+		if (prop.nestedClass || prop.isHasMany)
+		{
+			//if the ivar is an array, we need to make every element into JSON and then put them back in the array
+			if (isArray)
+			{
+				NSMutableArray *new = [NSMutableArray arrayWithCapacity:[val count]];
+				
+				for (int i = 0; i < [val count]; i++)
+				{
+					id element = [val objectAtIndex:i];
+					
+					id encodedObj = element;
+					
+					//if it's an NSRailsModel, we can use its dictionaryOfRemoteProperties
+					if ([element isKindOfClass:[NSRailsManagedObject class]])
+					{
+						//have to make it shallow so we don't loop infinitely (if that model defines us as an assc)
+						encodedObj = [element dictionaryOfRemotePropertiesShallow:YES];
+					}
+					else if ([element isKindOfClass:[NSDate class]])
+					{
+						encodedObj = [self nsrails_encodeDate:element];
+					}
+					
+					[new addObject:encodedObj];
+				}
+				return new;
+			}
+			
+			//otherwise, make that nested object a dictionary through NSRailsModel
+			//first make sure it's an NSRailsModel subclass
+			if (![val isKindOfClass:[NSRailsManagedObject class]])
+				return nil;
+			
+			//have to make it shallow so we don't loop infinitely (if that model defines us as an assc)
+			return [val dictionaryOfRemotePropertiesShallow:YES];
+		}
+				
+		//otherwise, just return the value from the get method
+		return val;
+	}
+	return nil;
+}
+
+- (id) initWithRemoteDictionary:(NSDictionary *)railsDict
+{
+  self = [[self class] findExistingModelWithPrimaryKeyAttributeValue:[railsDict objectForKey:[[self class] primaryKeyAttributeName]]];
+	if (self)
+	{
+		[self setPropertiesUsingRemoteDictionary:railsDict];
+	}
+	return self;
+}
+
+- (id) initWithRemoteJSON:(NSString *)json
+{
+  NSManagedObjectContext *ctx = [NSManagedObjectContext MR_defaultContext];
+  NSEntityDescription *desc = [NSEntityDescription entityForName:[[self class] description] inManagedObjectContext:ctx];
+  
+  self = [[NSRailsManagedObject alloc] initWithEntity:desc insertIntoManagedObjectContext:ctx];
+  
+	if (self)
+	{
+		[self setPropertiesUsingRemoteJSON:json];
+	}
+	return self;
+}
+
+- (BOOL) setPropertiesUsingRemoteDictionary:(NSDictionary *)dict
+{
+	//support JSON that comes in like {"post"=>{"something":"something"}}
+	NSDictionary *innerDict = [dict objectForKey:[[self class] masterModelName]];
+	if (dict.count == 1 && innerDict)
+	{
+		dict = innerDict;
+		if ([dict isKindOfClass:[NSNull class]])
+		{
+			NSLog(@"NSR Warning: Tried to set root-level instance of %@ to null. Ignoring.", dict);
+			return NO;
+		}
+	}
+	
+	remoteAttributes = dict;
+	
+	BOOL changes = NO;
+	
+	for (NSString *railsProperty in dict)
+	{
+		NSArray *equivalents = [[self propertyCollection] objcPropertiesForRemoteEquivalent:railsProperty 
+																				autoinflect:[self getRelevantConfig].autoinflectsPropertyNames];
+		
+		//loop through just in case there are multiple objcProps set to retrieve same remoteEquiv
+		for (NSRProperty *property in equivalents)
+		{
+			if (!property.retrievable)
+				continue;
+			
+			id railsObject = [dict objectForKey:railsProperty];
+			if (railsObject == [NSNull null])
+				railsObject = nil;
+			
+			SEL getter = [[self class] getterForProperty:property.name];
+			SEL setter = [[self class] setterForProperty:property.name];
+			
+			id previousVal = [self performSelector:getter];
+			
+			SEL customDecode = NULL;
+			if (property.decodable)
+			{
+				customDecode = NSSelectorFromString([NSString stringWithFormat:@"decode%@:",[property.name firstLetterCapital]]);
+			}
+			else if (property.isDate)
+			{
+				customDecode = @selector(nsrails_decodeDate:);
+			}
+			
+			id decodedObj = nil;
+			if (customDecode)
+			{
+				decodedObj = [self performSelector:customDecode withObject:railsObject];
+			}
+			else	
+			{
+				if (railsObject)
+				{
+					if (property.isHasMany && property.nestedClass)
+					{
+						if (![railsObject isKindOfClass:[NSArray class]])
+							[NSException raise:NSRailsInternalError format:@"Attempt to set property '%@' in class '%@' (declared as has-many) to a non-array non-null value ('%@').", property, self.class, railsObject];
+						
+						//array of NSRailsModels is tricky, we need to go through each existing element, see if it needs an update (or delete), and then add any new ones
+						
+						NSMutableArray *newArray = [[NSMutableArray alloc] init];
+						
+						for (id railsElement in railsObject)
+						{
+							id decodedElement;
+							
+							//array of NSDates
+							if ([property.nestedClass isEqualToString:@"NSDate"])
+							{
+								decodedElement = [self nsrails_decodeDate:railsElement];
+							}
+							
+							//otherwise, array of nested classes (NSRailsModels)
+							else
+							{
+								//see if there's a nester that matches this ID - we'd just have to update it w/this dict
+								NSUInteger idx = [previousVal indexOfObjectPassingTest:
+												  ^BOOL(NSRailsManagedObject *obj, NSUInteger idx, BOOL *stop) 
+												  {
+													  if ([obj.remoteID isEqualToNumber:[railsElement objectForKey:@"id"]])
+													  {
+														  if (stop)
+															  *stop = YES;
+														  return YES;
+													  }
+													  return NO;
+												  }];
+								
+								if (!previousVal || idx == NSNotFound)
+								{
+									//didn't previously exist - make a new one
+									decodedElement = [self makeRelevantModelFromClass:property.nestedClass basedOn:railsElement];
+									
+									changes = YES;
+								}
+								else
+								{
+									//existed - simply update that one (recursively)
+									decodedElement = [previousVal objectAtIndex:idx];
+									BOOL neededChange = [decodedElement setPropertiesUsingRemoteDictionary:railsElement];
+									
+									if (neededChange)
+										changes = YES;
+								}
+							}
+							
+							[newArray addObject:decodedElement];
+						}
+						
+						decodedObj = newArray;
+					}
+					else if (property.nestedClass)
+					{
+						//if the nested object didn't exist before, make it & set it
+						if (!previousVal)
+						{
+							decodedObj = [self makeRelevantModelFromClass:property.nestedClass basedOn:railsObject];
+							
+							changes = YES;
+						}
+						//otherwise, keep the old object & only mark as change if its properties changed (recursive)
+						else
+						{
+							decodedObj = previousVal;
+							
+							BOOL objChange = [decodedObj setPropertiesUsingRemoteDictionary:railsObject];
+							if (objChange)
+								changes = YES;
+						}
+					}
+					//otherwise, if not nested or anything, just use what we got (number, string, dictionary)
+					else
+					{
+						decodedObj = railsObject;
+					}
+				}
+				//if new value is nil
+				else
+				{
+					//if previous object existed, mark a change
+					if (previousVal)
+						changes = YES;
+				}
+			}
+			
+			//check for plain equality
+			if (![decodedObj isEqual:previousVal])
+			{
+				changes = YES;
+			}
+			
+			
+			[self performSelector:setter withObject:decodedObj];
+		}
+	}
+  [[NSManagedObjectContext MR_defaultContext] MR_save];
+	return changes;
+}
+
+- (NSDictionary *) dictionaryOfRemoteProperties
+{
+	return [self dictionaryOfRemotePropertiesShallow:NO];
+}
+
+- (NSDictionary *) dictionaryOfRemotePropertiesShallow:(BOOL)shallow
+{
+	NSMutableDictionary *dict = [NSMutableDictionary dictionary];
+	
+	for (NSRProperty *objcProperty in [self propertyCollection].properties.allValues)
+	{
+		//skip this property if it's nested and we're only looking shallow (to prevent infinite recursion), or if it's not sendable
+		if ((shallow && objcProperty.nestedClass) || !objcProperty.sendable)
+			continue;
+		
+		NSString *railsEquivalent = objcProperty.remoteEquivalent;
+		if (!railsEquivalent)
+		{
+			if ([NSRConfig defaultConfig].autoinflectsPropertyNames)
+				railsEquivalent = [objcProperty.name underscore];
+			else
+				railsEquivalent = objcProperty.name;
+		}
+		
+		id remoteRep = [self remoteRepresentationOfObjectForProperty:objcProperty];
+
+		BOOL null = !remoteRep;
+		
+		//if we got back nil, we want to change that to the [NSNull null] object so it'll show up in the JSON
+		//but only do it for non-ID properties - we want to omit ID if it's null (could be for create)
+		if (!remoteRep && ![railsEquivalent isEqualToString:@"id"])
+		{
+			if (objcProperty.isHasMany)
+			{
+				//make it an empty array (rails will get angry if you send null for an array)
+				remoteRep = [NSArray array];
+			}
+			else
+			{
+				remoteRep = [NSNull null];
+			}
+		}
+		if (remoteRep)
+		{
+			//if it's an array, remove any null values (wouldn't make sense in the array)
+			if (objcProperty.isHasMany)
+			{
+				for (int i = 0; i < [remoteRep count]; i++)
+				{
+					if ([remoteRep objectAtIndex:i] == [NSNull class])
+					{
+						[remoteRep removeObjectAtIndex:i];
+						i--;
+					}
+				}
+			}
+			
+			//this is the belongs_to trick
+			//if "-b" declared and it's not NSNull and the relation's remoteID exists, THEN, we should use _id instead of _attributes
+			if (objcProperty.isBelongsTo &&
+				!null &&
+				[remoteRep objectForKey:@"id"])
+			{
+				railsEquivalent = [railsEquivalent stringByAppendingString:@"_id"];
+				
+				//instead of the entire array, set the value to be only the ID
+				remoteRep = [remoteRep objectForKey:@"id"];
+			}
+			
+			//otherwise, if it's associative, use "_attributes" if not "null"
+			else if ((objcProperty.nestedClass || objcProperty.isHasMany) && !null)
+			{
+				railsEquivalent = [railsEquivalent stringByAppendingString:@"_attributes"];
+			}
+			
+			//check to see if it was already set (ie, ignore it if there are multiple properties pointing to the same rails attr)
+			[dict setObject:remoteRep forKey:railsEquivalent];
+		}
+	}
+
+	if (remoteDestroyOnNesting)
+	{
+		[dict setObject:[NSNumber numberWithBool:remoteDestroyOnNesting] forKey:@"_destroy"];
+	}
+	
+	return dict;
+}
+
+- (BOOL) setPropertiesUsingRemoteJSON:(NSString *)json
+{
+	if (!json)
+	{
+		NSLog(@"NSR Warning: Can't set attributes to nil JSON.");
+		return NO;
+
+		//decided to not make this raise an exception
+		//[NSException raise:@"NSRailsNilJSONException" format:@"Can't set attributes to nil JSON."];
+	}
+	
+	NSDictionary *dict = [json JSONValue];
+	
+	if (!dict)
+	{
+		[NSException raise:NSRailsJSONParsingException format:@"Failed trying to parse the following JSON into a dictionary: `%@`", json];
+	}
+	
+	return [self setPropertiesUsingRemoteDictionary:dict];
+}
+
+//pop the warning suppressor defined above (for calling performSelector's in ARC)
+#pragma clang diagnostic pop
+
+
+
+
+#pragma mark - HTTP Request stuff
+
++ (NSString *) routeForControllerMethod:(NSString *)customRESTMethod
+{
+	NSString *controller = [self masterPluralName];
+	NSString *route = customRESTMethod;
+	if (controller)
+	{
+		//this means this method was called on an NSRailsMethod _subclass_, so appropriately point the method to its controller
+		//eg, ([User makeGET:@"hello"] => myapp.com/users/hello)
+		route = [NSString stringWithFormat:@"%@%@",controller, (customRESTMethod ? [@"/" stringByAppendingString:customRESTMethod] : @"")];
+		
+		//otherwise, if it was called on NSRailsModel (to access a "root method"), don't modify the route:
+		//eg, ([NSRailsModel makeGET:@"hello"] => myapp.com/hello)
+	}
+	return (route ? route : @"");
+}
+
+- (NSString *) routeForInstanceMethod:(NSString *)customRESTMethod
+{
+	[self testIfCanSendInstanceRequest];
+
+	//make request on an instance, so make route "id", or "id/route" if there's an additional route included (1/edit)
+	NSString *idAndMethod = [NSString stringWithFormat:@"%@%@",self.remoteID,(customRESTMethod ? [@"/" stringByAppendingString:customRESTMethod] : @"")];
+	
+	return [[self class] routeForControllerMethod:idAndMethod];
+}
+
+
+#pragma mark Performing actions on instances
+
+- (void) testIfCanSendInstanceRequest
+{
+	if (!self.remoteID)
+	{
+		[NSException raise:NSRailsNullRemoteIDException format:@"Attempted to update, delete, or retrieve an object with no ID. (Instance of %@)",NSStringFromClass([self class])];
+	}
+}
+
+- (NSString *) remoteRequest:(NSString *)httpVerb method:(NSString *)customRESTMethod body:(NSString *)body error:(NSError **)error
+{
+	NSString *route = [self routeForInstanceMethod:customRESTMethod];
+	return [[self getRelevantConfig] makeRequest:httpVerb requestBody:body route:route sync:error orAsync:nil];
+}
+
+- (void) remoteRequest:(NSString *)httpVerb method:(NSString *)customRESTMethod body:(NSString *)body async:(NSRHTTPCompletionBlock)completionBlock
+{
+	NSString *route = [self routeForInstanceMethod:customRESTMethod];
+	[[self getRelevantConfig] makeRequest:httpVerb requestBody:body route:route sync:nil orAsync:completionBlock];
+}
+
+//these are really just convenience methods that'll call the above method sending the object data as request body
+
+- (NSString *) remoteRequest:(NSString *)httpVerb method:(NSString *)customRESTMethod error:(NSError **)error
+{
+	//done again so it can be tested before converting to JSON
+	[self testIfCanSendInstanceRequest];
+	
+	return [self remoteRequest:httpVerb method:customRESTMethod body:[self remoteJSONRepresentation] error:error];
+}
+
+- (void) remoteRequest:(NSString *)httpVerb method:(NSString *)customRESTMethod async:(NSRHTTPCompletionBlock)completionBlock
+{
+	[self testIfCanSendInstanceRequest];
+	
+	[self remoteRequest:httpVerb method:customRESTMethod body:[self remoteJSONRepresentation] async:completionBlock];
+}
+
+//these are really just convenience methods that'll call the above method with pre-built "GET" and no body
+
+- (NSString *) remoteGET:(NSString *)customRESTMethod error:(NSError **)error
+{
+	return [self remoteRequest:@"GET" method:customRESTMethod body:nil error:error];
+}
+
+- (void) remoteGET:(NSString *)customRESTMethod async:(NSRHTTPCompletionBlock)completionBlock
+{
+	[self remoteRequest:@"GET" method:customRESTMethod body:nil async:completionBlock];
+}
+
+
+#pragma mark Performing actions on classes
+
+
++ (NSString *)	remoteRequest:(NSString *)httpVerb method:(NSString *)customRESTMethod body:(NSString *)body error:(NSError **)error
+{
+	NSString *route = [self routeForControllerMethod:customRESTMethod];
+	return [[self getRelevantConfig] makeRequest:httpVerb requestBody:body route:route sync:error orAsync:nil];
+}
+
++ (void) remoteRequest:(NSString *)httpVerb method:(NSString *)customRESTMethod body:(NSString *)body async:(NSRHTTPCompletionBlock)completionBlock
+{
+	NSString *route = [self routeForControllerMethod:customRESTMethod];
+	[[self getRelevantConfig] makeRequest:httpVerb requestBody:body route:route sync:nil orAsync:completionBlock];
+}
+
+//these are really just convenience methods that'll call the above method with the JSON representation of the object
+
++ (NSString *)	remoteRequest:(NSString *)httpVerb method:(NSString *)customRESTMethod bodyAsObject:(NSRailsManagedObject *)obj error:(NSError **)error
+{
+	return [self remoteRequest:httpVerb method:customRESTMethod body:[obj remoteJSONRepresentation] error:error];
+}
+
++ (void) remoteRequest:(NSString *)httpVerb method:(NSString *)customRESTMethod bodyAsObject:(NSRailsManagedObject *)obj async:(NSRHTTPCompletionBlock)completionBlock
+{
+	[self remoteRequest:httpVerb method:customRESTMethod body:[obj remoteJSONRepresentation] async:completionBlock];
+}
+
+//these are really just convenience methods that'll call the above method with pre-built "GET" and no body
+
++ (NSString *) remoteGET:(NSString *)customRESTMethod error:(NSError **)error
+{
+	return [self remoteRequest:@"GET" method:customRESTMethod body:nil error:error];
+}
+
++ (void) remoteGET:(NSString *)customRESTMethod async:(NSRHTTPCompletionBlock)completionBlock
+{
+	[self remoteRequest:@"GET" method:customRESTMethod body:nil async:completionBlock];
+}
+
+
+
+#pragma mark - External stuff (CRUD)
+
+#pragma mark Create
+
+- (BOOL) remoteCreate:(NSError **)error
+{
+	NSString *jsonResponse = [[self class] remoteRequest:@"POST" method:nil bodyAsObject:self error:error];
+	if (!jsonResponse)
+		return NO;
+	
+	[self setPropertiesUsingRemoteJSON:jsonResponse];
+	
+	return YES;
+}
+
+- (void) remoteCreateAsync:(NSRBasicCompletionBlock)completionBlock
+{
+	[[self class] remoteRequest:@"POST" method:nil bodyAsObject:self async:
+	 
+	 ^(NSString *result, NSError *error) {
+		 if (result)
+			 [self setPropertiesUsingRemoteJSON:result];
+		 completionBlock(error);
+	 }];
+}
+
+#pragma mark Update
+
+- (BOOL) remoteUpdate:(NSError **)error
+{
+	return !![self remoteRequest:@"PUT" method:nil error:error];
+}
+
+- (void) remoteUpdateAsync:(NSRBasicCompletionBlock)completionBlock
+{
+	[self remoteRequest:@"PUT" method:nil async:
+	 
+	 ^(NSString *result, NSError *error) {
+		 completionBlock(error);
+	 }];
+}
+
+#pragma mark Destroy
+
+- (BOOL) remoteDestroy:(NSError **)error
+{
+	return !![self remoteRequest:@"DELETE" method:nil body:nil error:error];
+}
+
+- (void) remoteDestroyAsync:(NSRBasicCompletionBlock)completionBlock
+{
+	[self remoteRequest:@"DELETE" method:nil body:nil async:
+	 ^(NSString *result, NSError *error) 
+	{
+		completionBlock(error);
+	}];
+}
+
+#pragma mark Get latest
+
+- (BOOL) remoteFetch:(NSError **)error changes:(BOOL *)changesPtr
+{
+	NSString *jsonResponse = [self remoteGET:nil error:error];
+	
+	if (!jsonResponse)
+		return NO;
+	
+	BOOL changes = [self setPropertiesUsingRemoteJSON:jsonResponse];
+	if (changesPtr)
+		*changesPtr = changes;
+	
+  [[NSManagedObjectContext MR_context] MR_save];
+	return YES;
+}
+
+- (BOOL) remoteFetch:(NSError **)error
+{
+	return [self remoteFetch:error changes:NULL];
+}
+
+- (void) remoteFetchAsync:(NSRGetLatestCompletionBlock)completionBlock
+{
+	[self remoteGET:nil async:
+	 ^(NSString *result, NSError *error) 
+	 {
+		 BOOL change = NO;
+		 if (result)
+			change = [self setPropertiesUsingRemoteJSON:result];
+     
+    [[NSManagedObjectContext MR_context] MR_save];
+     
+		 completionBlock(change, error);
+	 }];
+}
+
+#pragma mark Get specific object (class-level)
+
++ (id) remoteObjectWithID:(NSInteger)mID error:(NSError **)error
+{
+  NSRailsManagedObject *obj = [self findExistingModelWithPrimaryKeyAttributeValue:[NSNumber numberWithInteger:mID]];
+  
+	obj.remoteID = [NSDecimalNumber numberWithInteger:mID];
+	
+	if (![obj remoteFetch:error])
+	{
+		obj = nil;
+	}
+
+	return obj;
+}
+
++ (void) remoteObjectWithID:(NSInteger)mID async:(NSRGetObjectCompletionBlock)completionBlock
+{
+#pragma warning - Altered here
+  
+  NSRailsManagedObject *obj = [self findExistingModelWithPrimaryKeyAttributeValue:[NSNumber numberWithInteger:mID]];
+  
+	obj.remoteID = [NSDecimalNumber numberWithInteger:mID];
+		
+	[obj remoteFetchAsync:
+	 
+	 ^(BOOL changed, NSError *error) {
+		if (error)
+			completionBlock(nil, error);
+		else
+			completionBlock(obj, error);
+	}];
+}
+
+#pragma mark Get all objects (class-level)
+
+//helper method for both sync+async for remoteAll
++ (NSArray *) arrayOfModelsFromJSON:(NSString *)json error:(NSError **)error
+{
+	//transform result into array (via json)
+	id arr = [json JSONValue];
+	
+	if (![arr isKindOfClass:[NSArray class]])
+	{
+		[NSException raise:NSRailsInternalError format:@"getAll method (index) for %@ controller (from %@ class) retuned this JSON: `%@`, which is not an array - check your server output.", [self masterPluralName], self.class, json];
+		return nil;
+	}
+	
+	//here comes actually making the array to return
+	
+	NSMutableArray *objects = [NSMutableArray array];
+	
+	//iterate through every object returned by Rails (as dicts)
+	for (NSDictionary *dict in arr)
+	{
+    NSString *attr_name = [[self class] primaryKeyAttributeName];
+    NSRailsManagedObject *obj = [[self class] findExistingModelWithPrimaryKeyAttributeValue:[dict objectForKey:attr_name]];		
+		[objects addObject:obj];
+	}
+	
+	return objects;
+}
+
++ (NSArray *) remoteAll:(NSError **)error
+{
+	//make a class GET call (so just the controller - myapp.com/users)
+	NSString *json = [self remoteGET:nil error:error];
+	if (!json)
+	{
+		return nil;
+	}
+	return [self arrayOfModelsFromJSON:json error:error];
+}
+
++ (void) remoteAllAsync:(NSRGetAllCompletionBlock)completionBlock
+{
+	[self remoteGET:nil async:
+	 ^(NSString *result, NSError *error) 
+	 {
+		 if (!result)
+		 {
+			 completionBlock(nil, error);
+		 }
+		 else
+		 {
+			 //make an array from the result returned async, and we can reuse the same error ptr (since we know it's nil)
+			 NSArray *array = [self arrayOfModelsFromJSON:result error:&error];
+			 completionBlock(array,error);
+		 }
+	 }];
+}
+
+
+#pragma mark - NSCoding
+
+- (id) initWithCoder:(NSCoder *)aDecoder
+{
+  NSNumber *rID = [aDecoder decodeObjectForKey:@"remoteID"];
+  self = [[self class] findExistingModelWithPrimaryKeyAttributeValue:rID];
+  
+	if (self)
+	{
+		self.remoteID = rID;
+		remoteAttributes = [aDecoder decodeObjectForKey:@"remoteAttributes"];
+		self.remoteDestroyOnNesting = [aDecoder decodeBoolForKey:@"remoteDestroyOnNesting"];
+		
+		customProperties = [aDecoder decodeObjectForKey:@"customProperties"];
+	}
+	return self;
+}
+
+- (void) encodeWithCoder:(NSCoder *)aCoder
+{
+	[aCoder encodeObject:remoteID forKey:@"remoteID"];
+	[aCoder encodeObject:remoteAttributes forKey:@"remoteAttributes"];
+	[aCoder encodeBool:remoteDestroyOnNesting forKey:@"remoteDestroyOnNesting"];
+	
+	[aCoder encodeObject:customProperties forKey:@"customProperties"];
+}
+
+#pragma mark - CoreData helpers
+
++ (id)findExistingModelWithPrimaryKeyAttributeValue:(id)value {
+  NSManagedObjectContext *ctx = [NSManagedObjectContext MR_defaultContext];
+  NSString *attribute_name = [self primaryKeyAttributeName];
+  
+  NSRailsManagedObject *obj = [[self class] MR_findFirstByAttribute:attribute_name withValue:value];
+//  NSRailsManagedObject *obj = [[self class] findFirstObjectByAttribute:attribute_name withValue:value inContext:ctx];
+  if (obj == nil) {
+    obj = [[self class] MR_createEntity];
+    [ctx MR_save];
+  }
+  obj.remoteID = value;
+  return obj;
+}
+
++ (NSString *)primaryKeyAttributeName {
+  NSString *attribute_name = [[[[self class] description] lowercaseString] stringByAppendingString:@"_id"];  
+  return attribute_name;
+}
+
++ (id)new {
+  NSManagedObjectContext *ctx = [NSManagedObjectContext MR_defaultContext];
+  NSEntityDescription *desc = [NSEntityDescription entityForName:[[self class] description] inManagedObjectContext:ctx];
+  
+  NSRailsManagedObject *obj = [[NSRailsManagedObject alloc] initWithEntity:desc insertIntoManagedObjectContext:ctx];
+  return obj;
+}
+
++ (NSRailsManagedObject *)findFirstObjectByAttribute:(NSString *)attr_name withValue:(id)value inContext:(NSManagedObjectContext *)context {
+  NSFetchRequest *fetch = [[NSFetchRequest alloc] initWithEntityName:NSStringFromClass([self class])];
+  NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%K == %@", attr_name, value];
+  fetch.predicate = predicate;
+  fetch.fetchLimit = 1;
+  
+  NSError *error = nil;
+  NSArray *results = [context executeFetchRequest:fetch error:&error];
+  if (results.count > 0) {
+    return [results objectAtIndex:0];
+  }
+  return nil;
+}
+
+@end

--- a/nsrails/Source/NSRailsManagedObject.m
+++ b/nsrails/Source/NSRailsManagedObject.m
@@ -55,6 +55,13 @@
 + (NSRPropertyCollection *) propertyCollection;
 - (NSRPropertyCollection *) propertyCollection;
 
++ (void) saveContext;
+- (void) saveContext;
+
+- (NSDictionary *) dictionaryOfRemotePropertiesShallow:(BOOL)shallow;
+- (void) testIfCanSendInstanceRequest;
++ (NSRailsManagedObject *)findFirstObjectByAttribute:(NSString *)attr_name withValue:(id)value inContext:(NSManagedObjectContext *)context;
+
 @end
 
 @interface NSRConfig (override)

--- a/nsrails/Source/NSRailsManagedObject.m
+++ b/nsrails/Source/NSRailsManagedObject.m
@@ -558,8 +558,9 @@ NSRailsSync(*);
 							
 							[newArray addObject:decodedElement];
 						}
-						
-						decodedObj = newArray;
+            NSMutableOrderedSet *s = [NSMutableOrderedSet orderedSetWithArray:newArray];
+            decodedObj = s;
+//            decodedObj = newArray;
 					}
 					else if (property.nestedClass)
 					{

--- a/nsrails/Source/NSRailsManagedObject.m
+++ b/nsrails/Source/NSRailsManagedObject.m
@@ -1150,7 +1150,7 @@ NSRailsSync(*);
 //  if (error) {
 //    NSLog(@"Failed to save core data: %@", [error localizedDescription]);
 //  }
-    [[NSNotificationCenter defaultCenter] postNotificationName:@"should_save_core_data" object:nil];
+    [[NSNotificationCenter defaultCenter] postNotificationName:(NSString *)NSRailsSaveCoreDataNotification object:nil];
 }
 
 - (void)saveContext {
@@ -1160,7 +1160,7 @@ NSRailsSync(*);
 //  if (error) {
 //    NSLog(@"Failed to save core data: %@", [error localizedDescription]);
 //  }  
-  [[NSNotificationCenter defaultCenter] postNotificationName:@"should_save_core_data" object:nil];
+  [[NSNotificationCenter defaultCenter] postNotificationName:(NSString *)NSRailsSaveCoreDataNotification object:nil];
 }
 
 - (void)awakeFromFetch {

--- a/nsrails/Source/NSRailsModel.m
+++ b/nsrails/Source/NSRailsModel.m
@@ -54,6 +54,9 @@
 + (NSRPropertyCollection *) propertyCollection;
 - (NSRPropertyCollection *) propertyCollection;
 
+- (NSDictionary *) dictionaryOfRemotePropertiesShallow:(BOOL)shallow;
+- (void) testIfCanSendInstanceRequest;
+
 @end
 
 @interface NSRConfig (override)


### PR DESCRIPTION
I created an NSRailsManagedObject object by copying/pasting the code from NSRailsModel. NSRailsManagedObject, however, inherits from NSManagedObject rather than NSObject. When the CRUD and fetch operations succeed, the corresponding objects in Core Data (uniquely identified by their primary key attribute) are updated, and the Core Data managed object context is saved.

The primary key attribute is assumed to be classname_id in the Core Data model. So for a class named "User", the primary key would be "user_id". 

Setup requires that the entities which should inherit from NSRailsManagedObject have their class set in the right pane of Xcode's data model editor (in the *.xcdatamodeld file) to the entity name. Otherwise, Core Data assumes that the entity's class inherits from NSManagedObject directly, and the application will crash.

remoteCreate will create the object locally and send a request to the server to create the object. 

remoteUpdate will attempt to update the server's record, and if the request succeeds, the object will be saved locally. Otherwise, changes will be rolled back if you have implemented an undo manager for the core data managed object context. 

remoteDestroy will send a request to the server to destroy the remote object. If successful, the local object will be deleted from Core Data. 

remoteFetch will update the attributes of the object in Core Data and save it, if successful. 
