### PR TITLE
allow OAuth token to be set in Authorization field

### DIFF
--- a/nsrails/Source/NSRConfig.h
+++ b/nsrails/Source/NSRConfig.h
@@ -271,6 +271,11 @@ extern NSString * const NSRCoreDataException;
 @property (nonatomic, strong) NSString *appPassword;
 
 /**
+ Token for OAuth authentication (if used by server.)
+ */
+@property (nonatomic, strong) NSString *appOAuthToken;
+
+/**
  Date [format]("https://developer.apple.com/library/mac/#documentation/Cocoa/Conceptual/DataFormatting/Articles/dfDateFormatting10_4.html%23//apple_ref/doc/uid/TP40002369-SW4") used if a property of type NSDate is encountered, to "encode" and "decode" NSDate objects.
  
  This should not be changed unless the format is also changed server-side; the default is the default Rails format.

--- a/nsrails/Source/NSRConfig.m
+++ b/nsrails/Source/NSRConfig.m
@@ -106,7 +106,7 @@ NSString * const NSRCoreDataException				= @"NSRCoreDataException";
 #endif
 
 @implementation NSRConfig
-@synthesize appURL, appUsername, appPassword;
+@synthesize appURL, appUsername, appPassword, appOAuthToken;
 @synthesize autoinflectsClassNames, autoinflectsPropertyNames, managesNetworkActivityIndicator, timeoutInterval, ignoresClassPrefixes, succinctErrorMessages, performsCompletionBlocksOnMainThread, managedObjectContext;
 @dynamic dateFormat;
 
@@ -453,6 +453,11 @@ static NSString *currentEnvironment = nil;
 		
 		[request setValue:authHeader forHTTPHeaderField:@"Authorization"]; 
 	}
+  else if (self.appOAuthToken)
+  {
+    NSString *authHeader = [NSString stringWithFormat:@"OAuth %@", self.appOAuthToken];
+    [request setValue:authHeader forHTTPHeaderField:@"Authorization"];
+  }
 	
 	if (body)
 	{


### PR DESCRIPTION
The OAuth 2 spec looks like it accepts the token in the Authorization header when prefixed with "OAuth " instead of "Basic ".
