### PR TITLE
Make NSCoding implementation  always encode properties to NSData, and de...

### DIFF
--- a/nsrails/Source/NSRRemoteObject.m
+++ b/nsrails/Source/NSRRemoteObject.m
@@ -40,7 +40,9 @@
 
 @interface NSRRemoteObject (private)
 
-- (NSDictionary *) dictionaryRepresentationWrapped:(BOOL)wrapped fromNesting:(BOOL)nesting remoteOnly:(BOOL)remote;
+- (NSDictionary *) dictionaryRepresentationWrapped:(BOOL)wrapped
+                                       fromNesting:(BOOL)nesting
+                                        remoteOnly:(BOOL)remote;
 + (NSArray *) arrayOfInstancesFromRemoteJSON:(id)json;
 
 - (BOOL) propertyIsTimestamp:(NSString *)property;
@@ -390,7 +392,9 @@
 	return [self dictionaryRepresentationWrapped:wrapped fromNesting:NO remoteOnly:YES];
 }
 
-- (NSDictionary *) dictionaryRepresentationWrapped:(BOOL)wrapped fromNesting:(BOOL)nesting remoteOnly:(BOOL)remote
+- (NSDictionary *) dictionaryRepresentationWrapped:(BOOL)wrapped
+                                       fromNesting:(BOOL)nesting
+                                        remoteOnly:(BOOL)remote
 {
 	NSMutableDictionary *dict = [NSMutableDictionary dictionary];
 	

--- a/nsrails/Source/NSRRemoteObject.m
+++ b/nsrails/Source/NSRRemoteObject.m
@@ -40,7 +40,7 @@
 
 @interface NSRRemoteObject (private)
 
-- (NSDictionary *) remoteDictionaryRepresentationWrapped:(BOOL)wrapped fromNesting:(BOOL)nesting;
+- (NSDictionary *) dictionaryRepresentationWrapped:(BOOL)wrapped fromNesting:(BOOL)nesting remoteOnly:(BOOL)remote;
 + (NSArray *) arrayOfInstancesFromRemoteJSON:(id)json;
 
 - (BOOL) propertyIsTimestamp:(NSString *)property;
@@ -209,14 +209,18 @@
 			
 			for (id element in val)
 			{
-				id encodedObj = [element remoteDictionaryRepresentationWrapped:NO fromNesting:YES];
+				id encodedObj = [element dictionaryRepresentationWrapped:NO
+                                                             fromNesting:YES
+                                                              remoteOnly:YES];
 				[new addObject:encodedObj];
 			}
 			
 			return new;
 		}
 		
-		return [val remoteDictionaryRepresentationWrapped:NO fromNesting:YES];
+		return [val dictionaryRepresentationWrapped:NO
+                                        fromNesting:YES
+                                         remoteOnly:YES];
 	}
 
 	if ([val isKindOfClass:[NSDate class]])
@@ -383,16 +387,16 @@
 
 - (NSDictionary *) remoteDictionaryRepresentationWrapped:(BOOL)wrapped
 {
-	return [self remoteDictionaryRepresentationWrapped:wrapped fromNesting:NO];
+	return [self dictionaryRepresentationWrapped:wrapped fromNesting:NO remoteOnly:YES];
 }
 
-- (NSDictionary *) remoteDictionaryRepresentationWrapped:(BOOL)wrapped fromNesting:(BOOL)nesting
+- (NSDictionary *) dictionaryRepresentationWrapped:(BOOL)wrapped fromNesting:(BOOL)nesting remoteOnly:(BOOL)remote
 {
 	NSMutableDictionary *dict = [NSMutableDictionary dictionary];
 	
 	for (NSString *objcProperty in [self remoteProperties])
 	{
-		if (![self shouldSendProperty:objcProperty whenNested:nesting])
+		if (remote && ![self shouldSendProperty:objcProperty whenNested:nesting])
 			continue;
 		
 		NSString *remoteKey = objcProperty;
@@ -607,6 +611,7 @@
 	{
 		self.remoteID = [aDecoder decodeObjectForKey:@"remoteID"];
 		remoteAttributes = [aDecoder decodeObjectForKey:@"remoteAttributes"];
+        [self setPropertiesUsingRemoteDictionary:remoteAttributes];
 		self.remoteDestroyOnNesting = [aDecoder decodeBoolForKey:@"remoteDestroyOnNesting"];
 	}
 	return self;
@@ -615,7 +620,10 @@
 - (void) encodeWithCoder:(NSCoder *)aCoder
 {
 	[aCoder encodeObject:self.remoteID forKey:@"remoteID"];
-	[aCoder encodeObject:remoteAttributes forKey:@"remoteAttributes"];
+	[aCoder encodeObject:[self dictionaryRepresentationWrapped:NO
+                                                   fromNesting:NO
+                                                    remoteOnly:NO]
+                  forKey:@"remoteAttributes"];
 	[aCoder encodeBool:remoteDestroyOnNesting forKey:@"remoteDestroyOnNesting"];
 }
 

--- a/nsrails/Tests/RemoteObject.m
+++ b/nsrails/Tests/RemoteObject.m
@@ -598,5 +598,35 @@
 	STAssertEqualObjects(b.name, @"tweety", nil);
 }
 
+- (void) test_nscoding
+{
+    Post *pBefore = [[Post alloc] init];
+
+    pBefore.remoteID = @5;
+    pBefore.author = @"Arthur McWriterston";
+    pBefore.content = @"My name is ridiculous.";
+    pBefore.updatedAt = [NSDate date];
+    pBefore.remoteDestroyOnNesting = YES;
+    
+    NSData* pData = [NSKeyedArchiver archivedDataWithRootObject:pBefore];
+    Post* pAfter = [NSKeyedUnarchiver unarchiveObjectWithData:pData];
+
+
+    STAssertEqualObjects(pBefore.remoteID, pAfter.remoteID,
+                         @"The post's remoteID should match before and after being archived.");
+    STAssertEqualObjects(pBefore.content, pAfter.content,
+                         @"The post's remoteID should match before and after being archived.");
+    STAssertEqualObjects(pBefore.author, pAfter.author,
+                         @"The post's author should match before and after being archived.");
+    
+    // During the encoding/decoding process, we seem to lose a few milli/nanoseconds.
+    // Get around caring about these by doing an NSTimeInterval, which goes by seconds.
+    NSInteger tiBetween = [pBefore.updatedAt timeIntervalSinceDate:pAfter.updatedAt];
+    STAssertTrue(tiBetween == 0,
+                 @"The post's updatedAt should match before and after being archived.");
+    STAssertTrue(pAfter.remoteDestroyOnNesting, @"remoteDestroyOnNesting should match before and after being archived.");
+}
+
+
 
 @end

--- a/nsrails/Tests/RemoteObject.m
+++ b/nsrails/Tests/RemoteObject.m
@@ -611,7 +611,6 @@
     NSData* pData = [NSKeyedArchiver archivedDataWithRootObject:pBefore];
     Post* pAfter = [NSKeyedUnarchiver unarchiveObjectWithData:pData];
 
-
     STAssertEqualObjects(pBefore.remoteID, pAfter.remoteID,
                          @"The post's remoteID should match before and after being archived.");
     STAssertEqualObjects(pBefore.content, pAfter.content,


### PR DESCRIPTION
`encodeWithCoder` would use `remoteAttributes`, which, in some rare scenarios (manually changing properties on an object) would not be accurate.

More importantly, `initWithCoder` would set the `remoteAttributes` but not use them to set the properties of the object.

I've included tests, and they should have good coverage!

Open to critique on general coding style or anything else!
