### PR TITLE
Allow setting of POST body to a string

### DIFF
--- a/nsrails/Source/NSRRequest.m
+++ b/nsrails/Source/NSRRequest.m
@@ -334,7 +334,6 @@ NSRLogTagged(inout, @"%@ %@", [NSString stringWithFormat:__VA_ARGS__],(NSRLog > 
   {
         NSData *data;
         if ([body isKindOfClass:[NSString class]]){
-            [request setValue:@"application/x-www-form-urlencoded" forHTTPHeaderField:@"Content-Type"];
             data = [body dataUsingEncoding:NSUTF8StringEncoding];
         }
         else{

--- a/nsrails/Source/NSRRequest.m
+++ b/nsrails/Source/NSRRequest.m
@@ -330,20 +330,25 @@ NSRLogTagged(inout, @"%@ %@", [NSString stringWithFormat:__VA_ARGS__],(NSRLog > 
 		[request setValue:authHeader forHTTPHeaderField:@"Authorization"];
 	}
 	
-	if (body)
-	{
-		//let it raise an exception if invalid json object
-		NSError *e = nil;
-		NSData *data = [NSJSONSerialization dataWithJSONObject:body options:0 error:&e];
-		
-		if (data)
-		{
-			[request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
-			[request setHTTPBody:data];
-			
-			[request setValue:[NSNumber numberWithUnsignedInteger:data.length].stringValue forHTTPHeaderField:@"Content-Length"];
-		}
- 	}
+  if (body)
+  {
+        NSData *data;
+        NSError *e = nil;
+        if ([body isKindOfClass:[NSString class]]){
+            [request setValue:@"application/x-www-form-urlencoded" forHTTPHeaderField:@"Content-Type"];
+            data = [(NSString*)body dataUsingEncoding:NSUTF8StringEncoding];
+        }
+        else{
+            //let it raise an exception if invalid json object
+            data = [NSJSONSerialization dataWithJSONObject:body options:0 error:&e];
+            if (data)
+            {
+                [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];                
+            }
+        }
+        [request setHTTPBody:data];
+        [request setValue:[NSNumber numberWithUnsignedInteger:data.length].stringValue forHTTPHeaderField:@"Content-Length"];
+  }
 	
 	return request;
 }

--- a/nsrails/Source/NSRRequest.m
+++ b/nsrails/Source/NSRRequest.m
@@ -333,14 +333,13 @@ NSRLogTagged(inout, @"%@ %@", [NSString stringWithFormat:__VA_ARGS__],(NSRLog > 
   if (body)
   {
         NSData *data;
-        NSError *e = nil;
         if ([body isKindOfClass:[NSString class]]){
             [request setValue:@"application/x-www-form-urlencoded" forHTTPHeaderField:@"Content-Type"];
-            data = [(NSString*)body dataUsingEncoding:NSUTF8StringEncoding];
+            data = [body dataUsingEncoding:NSUTF8StringEncoding];
         }
         else{
             //let it raise an exception if invalid json object
-            data = [NSJSONSerialization dataWithJSONObject:body options:0 error:&e];
+            data = [NSJSONSerialization dataWithJSONObject:body options:0 error:nil];
             if (data)
             {
                 [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];                

--- a/nsrails/Source/NSRRequest.m
+++ b/nsrails/Source/NSRRequest.m
@@ -335,6 +335,11 @@ NSRLogTagged(inout, @"%@ %@", [NSString stringWithFormat:__VA_ARGS__],(NSRLog > 
         NSData *data;
         if ([body isKindOfClass:[NSString class]]){
             data = [body dataUsingEncoding:NSUTF8StringEncoding];
+            if (!additionalHTTPHeaders[@"Content-Type"])
+            {
+                [NSException raise:@"NSRRequest Error"
+                            format:@"POST body was set as a string, but no Content-Type header was specific. Please use -[NSRRequest setAdditionalHTTPHeaders:...]"];
+            }
         }
         else{
             //let it raise an exception if invalid json object

--- a/nsrails/Tests/Integration.m
+++ b/nsrails/Tests/Integration.m
@@ -360,11 +360,6 @@ static BOOL noServer = NO;
 	
 	e = nil;
 	
-    req = [NSRRequest POST];
-	[req routeTo:@"posts"];
-	req.body = @"STRING";
-	STAssertThrows([req sendSynchronous:&e], @"Should throw exception when sending invalid JSON");
-	
     req = [NSRRequest DELETE];
 	[req routeTo:[NSString stringWithFormat:@"posts/%@", p.remoteID]];
 	

--- a/nsrails/Tests/Integration.m
+++ b/nsrails/Tests/Integration.m
@@ -364,7 +364,7 @@ static BOOL noServer = NO;
 	[req routeTo:@"posts/create"];
 	req.body = @"post%5Bauthor%5D=another+author&post%5Bcontent%5D=more+content";
     [req setAdditionalHTTPHeaders:[@{@"Content-Type":@"application/x-www-form-urlencoded"} mutableCopy]];
-	STAssertNil(e, @"Should be no error creating posting with body equal to an NSString",e);
+	STAssertNil(e, @"Should be no error creating posting with body equal to a url encoded string",e);
 	
     req = [NSRRequest DELETE];
 	[req routeTo:[NSString stringWithFormat:@"posts/%@", p.remoteID]];

--- a/nsrails/Tests/Integration.m
+++ b/nsrails/Tests/Integration.m
@@ -360,6 +360,12 @@ static BOOL noServer = NO;
 	
 	e = nil;
 	
+    req = [NSRRequest POST];
+	[req routeTo:@"posts/create"];
+	req.body = @"post%5Bauthor%5D=another+author&post%5Bcontent%5D=more+content";
+    [req setAdditionalHTTPHeaders:[@{@"Content-Type":@"application/x-www-form-urlencoded"} mutableCopy]];
+	STAssertNil(e, @"Should be no error creating posting with body equal to an NSString",e);
+	
     req = [NSRRequest DELETE];
 	[req routeTo:[NSString stringWithFormat:@"posts/%@", p.remoteID]];
 	

--- a/nsrails/Tests/Request.m
+++ b/nsrails/Tests/Request.m
@@ -134,7 +134,7 @@
 	p.superString = @"dan";
 	[req setBodyToObject:p];
 	request = [req HTTPRequest];
-	STAssertEqualObjects([request HTTPBody], [@"{\"super_class\":{\"super_string\":\"dan\"}}" dataUsingEncoding:NSUTF8StringEncoding], nil);    
+	STAssertEqualObjects([request HTTPBody], [@"{\"super_class\":{\"super_string\":\"dan\"}}" dataUsingEncoding:NSUTF8StringEncoding], nil);
 }
 
 - (void) test_routing

--- a/nsrails/Tests/Request.m
+++ b/nsrails/Tests/Request.m
@@ -104,12 +104,13 @@
 	[req routeTo:@"hello"];
 	request = [req HTTPRequest];
 	STAssertEqualObjects([request.URL description], @"http://myapp.com/hello", nil);
-
-	req.body = @":f,aifj*(O#P:???";
-	STAssertThrows([req HTTPRequest], nil);
-
-	req.body = @"{hello:man}";
-	STAssertThrows([req HTTPRequest], nil);	
+    
+    req = [NSRRequest POST];    
+    NSString* strBody = @"this=that&thisarray[]=thatvalue";
+    [req setBody:strBody];
+    request = [req HTTPRequest];
+    NSData* data = [strBody dataUsingEncoding:NSUTF8StringEncoding];
+    STAssertEqualObjects(request.HTTPBody, data, @"Body of NSRRequest was not able to be set to an NSString");
 }
 
 /* With objects */
@@ -133,7 +134,7 @@
 	p.superString = @"dan";
 	[req setBodyToObject:p];
 	request = [req HTTPRequest];
-	STAssertEqualObjects([request HTTPBody], [@"{\"super_class\":{\"super_string\":\"dan\"}}" dataUsingEncoding:NSUTF8StringEncoding], nil);
+	STAssertEqualObjects([request HTTPBody], [@"{\"super_class\":{\"super_string\":\"dan\"}}" dataUsingEncoding:NSUTF8StringEncoding], nil);    
 }
 
 - (void) test_routing

--- a/nsrails/Tests/Request.m
+++ b/nsrails/Tests/Request.m
@@ -108,9 +108,16 @@
     req = [NSRRequest POST];    
     NSString* strBody = @"this=that&thisarray[]=thatvalue";
     [req setBody:strBody];
+    [req setAdditionalHTTPHeaders:[@{@"Content-Type":@"application/x-www-form-urlencoded"} mutableCopy]];
     request = [req HTTPRequest];
     NSData* data = [strBody dataUsingEncoding:NSUTF8StringEncoding];
     STAssertEqualObjects(request.HTTPBody, data, @"Body of NSRRequest was not able to be set to an NSString");
+    
+    [req setAdditionalHTTPHeaders:[@{} mutableCopy]];
+    STAssertThrows([req HTTPRequest], @"Should throw exception because no Content-Type header was given when POST body was set as a string.");
+
+    
+    
 }
 
 /* With objects */


### PR DESCRIPTION
It seemed best to not set a `content-type` like is done for JSON objects, and just leave it up to the user.
