### PR TITLE
Check for non-null data after response

### DIFF
--- a/nsrails/Source/NSRRequest.m
+++ b/nsrails/Source/NSRRequest.m
@@ -435,6 +435,13 @@ NSRLogTagged(inout, @"%@ %@", [NSString stringWithFormat:__VA_ARGS__],(NSRLog > 
     [self logOut:request];
 	NSData *data = [NSURLConnection sendSynchronousRequest:request returningResponse:&response error:&appleError];
 	
+    if (!data) {
+        if (errorOut)
+            *errorOut = appleError;
+        
+        return nil;
+    }
+    
 	id jsonResponse = [self jsonResponseFromData:data];
 	NSError *error = [self errorForResponse:jsonResponse existingError:appleError statusCode:response.statusCode];
 	
@@ -492,13 +499,19 @@ NSRLogTagged(inout, @"%@ %@", [NSString stringWithFormat:__VA_ARGS__],(NSRLog > 
 			 }
 		 }
 #endif
-		 id jsonResponse = [self jsonResponseFromData:data];
-		 NSError *error = [self errorForResponse:jsonResponse existingError:appleError statusCode:[(NSHTTPURLResponse *)response statusCode]];
-		 
-         [self logIn:jsonResponse error:error];
-         
-		 if (block)
-			 [self performCompletionBlock:^{ block( (error ? nil : jsonResponse), error); }];
+         if (!data) {
+             if (block)
+                 [self performCompletionBlock:^{ block( nil, appleError); }];
+                     
+         } else {
+             id jsonResponse = [self jsonResponseFromData:data];
+             NSError *error = [self errorForResponse:jsonResponse existingError:appleError statusCode:[(NSHTTPURLResponse *)response statusCode]];
+             
+             [self logIn:jsonResponse error:error];
+             
+             if (block)
+                 [self performCompletionBlock:^{ block( (error ? nil : jsonResponse), error); }];
+         }
 	 }];
 }
 


### PR DESCRIPTION
Check for non-null data after response and use existing error if data is null. This catches errors like “Could not connect to server” and prevents jsonResponsefromData from crashing on a null argument
